### PR TITLE
docs: add translated READMEs (13 languages)

### DIFF
--- a/docs/translations/README.ar.md
+++ b/docs/translations/README.ar.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <b>العربية</b> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## الميزات
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## المتطلبات
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## التثبيت
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## الإعدادات
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## الرخصة
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <b>Deutsch</b> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## Funktionen
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,7 +47,7 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## Voraussetzungen
 
 - Java 17+
 - Spring Boot 3.2+
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## Konfiguration
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## Lizenz
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <b>Español</b> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## Características
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## Requisitos
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## Instalación
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## Configuración
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## Licencia
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <b>Français</b> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## Fonctionnalités
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,7 +47,7 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## Prérequis
 
 - Java 17+
 - Spring Boot 3.2+
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## Licence
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <b>Italiano</b> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## Funzionalità
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## Requisiti
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## Installazione
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## Configurazione
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## Licenza
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <b>日本語</b> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## 機能
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## 要件
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## インストール
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## 設定
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## ライセンス
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <b>한국어</b> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## 기능
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## 요구 사항
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## 설치
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## 설정
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## 라이선스
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <b>Nederlands</b> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## Functies
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## Vereisten
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## Installatie
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## Configuratie
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## Licentie
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.pl.md
+++ b/docs/translations/README.pl.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <b>Polski</b> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## Funkcje
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## Wymagania
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## Instalacja
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## Konfiguracja
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## Licencja
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <b>Português (BR)</b> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## Recursos
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## Requisitos
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## Instalação
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## Configuração
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## Licença
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <b>Русский</b> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## Возможности
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## Требования
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## Установка
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## Конфигурация
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## Лицензия
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <b>Türkçe</b> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## Özellikler
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## Gereksinimler
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## Kurulum
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## Yapılandırma
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## Lisans
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -1,25 +1,25 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <b>简体中文</b>
 </p>
 
 # Escalated Spring
 
 An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
 
-## Features
+## 功能特性
 
 1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
 2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
@@ -47,13 +47,13 @@ An embeddable helpdesk system for Spring Boot applications. Add a full-featured 
 24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
 25. **Guest Access** -- Token-based ticket access without authentication
 
-## Requirements
+## 系统要求
 
 - Java 17+
 - Spring Boot 3.2+
 - A relational database (PostgreSQL, MySQL, or H2 for development)
 
-## Installation
+## 安装
 
 Add the dependency to your `build.gradle.kts`:
 
@@ -71,7 +71,7 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## Configuration
+## 配置
 
 Add to your `application.properties` or `application.yml`:
 
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## License
+## 许可证
 
 MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Add translated README files in `docs/translations/` for 13 languages: Arabic, German, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portuguese, Russian, Turkish, and Chinese Simplified
- Add language selector bar at the top of the main README.md
- Each translated README includes the same language selector with the current language bolded and translated section headings

## Test plan
- [ ] Verify language selector links work in the main README
- [ ] Verify each translated file has correct language selector
- [ ] Verify English links back to ../../README.md from translation files