### PR TITLE
fix: fully translate README content

### DIFF
--- a/docs/translations/README.ar.md
+++ b/docs/translations/README.ar.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+نظام مكتب مساعدة قابل للتضمين لتطبيقات Spring Boot. أضف مكتب دعم كامل الميزات إلى أي تطبيق Java بتبعية واحدة.
 
 ## الميزات
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- إدارة كاملة لدورة الحياة مع الحالات والأولويات والتعيينات
+2. **SLA Policies** -- اتفاقيات مستوى خدمة قابلة للتكوين مع دعم ساعات العمل وتقويمات العطلات
+3. **Automations** -- قواعد مبنية على الوقت لإغلاق التذاكر المحلولة تلقائياً والتعيين التلقائي
+4. **Escalation Rules** -- تصعيد تلقائي عند انتهاك SLA مع إعادة التعيين والإشعارات
+5. **Macros & Canned Responses** -- إجراءات محددة مسبقاً وقوالب استجابة للوكلاء
+6. **Custom Fields** -- بيانات تذاكر قابلة للتوسيع مع أنواع حقول متعددة
+7. **Knowledge Base** -- مقالات وفئات مع البحث وعدد المشاهدات والتعليقات
+8. **Webhooks** -- تسليم Webhook موقّع بـ HMAC مع منطق إعادة المحاولة
+9. **API Tokens** -- مصادقة بالرمز المميز المجزأ بـ SHA-256 للوصول إلى API
+10. **Roles & Permissions** -- تحكم دقيق في الوصول قائم على الأدوار
+11. **Audit Logging** -- سجل تدقيق كامل لجميع الإجراءات
+12. **Import System** -- استيراد جماعي للتذاكر من بيانات منظمة
+13. **Side Conversations** -- محادثات خاصة مترابطة داخل التذاكر
+14. **Ticket Merging & Linking** -- دمج التذاكر المكررة وربط التذاكر ذات الصلة
+15. **Ticket Splitting** -- تقسيم التذاكر المعقدة إلى مشكلات منفصلة
+16. **Ticket Snooze** -- تأجيل التذاكر مع إيقاظ تلقائي عبر `@Scheduled`
+17. **Email Threading** -- قوالب بريد إلكتروني HTML ذات علامة تجارية عبر Thymeleaf مع ترابط Message-ID صحيح
+18. **Saved Views** -- عروض تذاكر مخصصة مفلترة/مرتبة لكل وكيل
+19. **Widget API** -- نقاط نهاية REST عامة لتضمين أداة الدعم
+20. **Real-time Broadcasting** -- WebSocket عبر STOMP/SockJS (اختياري)
+21. **Capacity Management** -- تتبع وفرض حدود أعباء عمل الوكلاء
+22. **Skill-based Routing** -- توجيه التذاكر إلى وكلاء ذوي مهارات مطابقة
+23. **CSAT Ratings** -- استبيانات رضا العملاء مع وصول قائم على الرمز المميز
+24. **2FA (TOTP)** -- دعم كلمة مرور لمرة واحدة مبنية على الوقت لحسابات الوكلاء
+25. **Guest Access** -- وصول إلى التذاكر قائم على الرمز المميز بدون مصادقة
 
 ## المتطلبات
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- قاعدة بيانات علائقية (PostgreSQL أو MySQL أو H2 للتطوير)
 
 ## التثبيت
 
-Add the dependency to your `build.gradle.kts`:
+أضف التبعية إلى ملف `build.gradle.kts` الخاص بك:
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+أو `pom.xml`:
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## الإعدادات
 
-Add to your `application.properties` or `application.yml`:
+أضف إلى ملف `application.properties` أو `application.yml` الخاص بك:
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## إعداد قاعدة البيانات
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+ترحيلات Flyway مضمنة وتعمل تلقائياً. يقوم الترحيل بإنشاء جميع الجداول مع البادئة `escalated_` ويزرع الأدوار والأذونات الافتراضية.
 
-## API Endpoints
+## نقاط نهاية API
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| الطريقة | المسار | الوصف |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | عرض التذاكر (مع ترقيم وتصفية) |
+| POST | `/tickets` | إنشاء تذكرة |
+| GET | `/tickets/{id}` | الحصول على تذكرة |
+| PUT | `/tickets/{id}` | تحديث تذكرة |
+| POST | `/tickets/{id}/assign` | تعيين تذكرة |
+| POST | `/tickets/{id}/status` | تغيير الحالة |
+| POST | `/tickets/{id}/snooze` | تأجيل تذكرة |
+| POST | `/tickets/{id}/merge` | دمج التذاكر |
+| POST | `/tickets/{id}/split` | تقسيم تذكرة |
+| DELETE | `/tickets/{id}` | حذف تذكرة |
+| GET/POST | `/departments` | إدارة الأقسام |
+| GET/POST | `/agents` | إدارة الوكلاء |
+| GET/POST | `/webhooks` | إدارة Webhooks |
+| GET/POST | `/roles` | إدارة الأدوار |
+| GET/POST | `/custom-fields` | إدارة الحقول المخصصة |
+| GET/POST | `/settings` | إدارة الإعدادات |
+| GET | `/audit-logs` | عرض سجلات التدقيق |
+| POST | `/import/tickets` | استيراد التذاكر |
+| GET/POST | `/kb/categories` | إدارة فئات قاعدة المعرفة |
+| GET/POST | `/kb/articles` | إدارة مقالات قاعدة المعرفة |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| الطريقة | المسار | الوصف |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | عرض التذاكر المعينة/المفلترة |
+| GET | `/tickets/{id}` | عرض التذكرة |
+| POST | `/tickets/{id}/replies` | إضافة رد |
+| POST | `/tickets/{id}/macro/{macroId}` | تطبيق ماكرو |
+| POST | `/tickets/{id}/side-conversations` | إنشاء محادثة جانبية |
+| POST | `/tickets/{id}/links` | ربط التذاكر |
+| GET/POST | `/saved-views` | إدارة العروض المحفوظة |
+| GET/POST | `/canned-responses` | إدارة الردود الجاهزة |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| الطريقة | المسار | الوصف |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | عرض تذاكر العميل |
+| POST | `/tickets` | إنشاء تذكرة |
+| POST | `/tickets/{id}/replies` | إضافة رد |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| الطريقة | المسار | الوصف |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | إنشاء تذكرة (عامة) |
+| GET | `/tickets/{token}` | عرض التذكرة برمز الضيف |
+| POST | `/tickets/{token}/replies` | الرد عبر رمز الضيف |
+| GET | `/kb/search?query=` | البحث في قاعدة المعرفة |
+| POST | `/csat/{token}` | إرسال تقييم الرضا |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| الطريقة | المسار | الوصف |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | عرض التذكرة |
+| GET | `/tickets/{token}/replies` | عرض الردود |
+| POST | `/tickets/{token}/replies` | إضافة رد |
 
-## Architecture
+## البنية
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              التكوين التلقائي، الخصائص، إعدادات WebSocket
+  models/              كيانات JPA مع العلاقات الكاملة
+  repositories/        مستودعات Spring Data JPA
+  services/            منطق الأعمال (معاملاتي)
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             واجهة REST للمسؤول
+    agent/             واجهة REST للوكيل
+    customer/          واجهة REST للعميل
+    widget/            واجهة الأداة العامة
+  events/              أحداث تطبيق Spring + مستمع webhook
+  security/            مرشح مصادقة رمز API، إعدادات الأمان، 2FA
+  scheduling/          مهام @Scheduled (تأجيل، SLA، أتمتة)
 ```
 
-## Authentication
+## المصادقة
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+تستخدم نقاط نهاية API مصادقة رمز Bearer. أنشئ الرموز عبر واجهة المسؤول:
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+يتضمن الرد الرمز بنص عادي (يُعرض مرة واحدة فقط). استخدمه في الطلبات اللاحقة:
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (الوقت الحقيقي)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+فعّل بـ `escalated.broadcasting.enabled=true`. اتصل بـ `/escalated/ws` عبر SockJS/STOMP.
 
-## Development
+## التطوير
 
 ```bash
 # Build
@@ -222,6 +222,6 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
-## الرخصة
+## الترخيص
 
-MIT License. See [LICENSE](LICENSE) for details.
+رخصة MIT. انظر [LICENSE](LICENSE) للتفاصيل.

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Ein einbettbares Helpdesk-System für Spring Boot-Anwendungen. Fügen Sie jeder Java-Anwendung mit einer einzigen Abhängigkeit einen voll ausgestatteten Support-Desk hinzu.
 
 ## Funktionen
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- Vollständige Lebenszyklusverwaltung mit Status, Prioritäten und Zuweisungen
+2. **SLA Policies** -- Konfigurierbare SLAs mit Geschäftszeiten-Unterstützung und Feiertagskalendern
+3. **Automations** -- Zeitbasierte Regeln zum automatischen Schließen gelöster Tickets und automatischer Zuweisung
+4. **Escalation Rules** -- Automatische Eskalation bei SLA-Verletzung mit Neuzuweisung und Benachrichtigungen
+5. **Macros & Canned Responses** -- Vordefinierte Aktionen und Antwortvorlagen für Agenten
+6. **Custom Fields** -- Erweiterbare Ticketdaten mit mehreren Feldtypen
+7. **Knowledge Base** -- Artikel und Kategorien mit Suche, Aufrufzähler und Feedback
+8. **Webhooks** -- HMAC-signierte Webhook-Zustellung mit Wiederholungslogik
+9. **API Tokens** -- SHA-256-gehashte Token-Authentifizierung für API-Zugriff
+10. **Roles & Permissions** -- Granulare rollenbasierte Zugriffskontrolle
+11. **Audit Logging** -- Vollständiger Audit-Trail für alle Aktionen
+12. **Import System** -- Massenimport von Tickets aus strukturierten Daten
+13. **Side Conversations** -- Private Thread-Konversationen innerhalb von Tickets
+14. **Ticket Merging & Linking** -- Doppelte Tickets zusammenführen und verwandte verknüpfen
+15. **Ticket Splitting** -- Komplexe Tickets in separate Vorgänge aufteilen
+16. **Ticket Snooze** -- Tickets schlummern lassen mit automatischem Aufwecken über `@Scheduled`
+17. **Email Threading** -- Gebrandete HTML-E-Mail-Vorlagen über Thymeleaf mit korrektem Message-ID-Threading
+18. **Saved Views** -- Benutzerdefinierte gefilterte/sortierte Ticket-Ansichten pro Agent
+19. **Widget API** -- Öffentliche REST-Endpunkte zum Einbetten eines Support-Widgets
+20. **Real-time Broadcasting** -- WebSocket über STOMP/SockJS (optional)
+21. **Capacity Management** -- Arbeitslastgrenzen für Agenten verfolgen und durchsetzen
+22. **Skill-based Routing** -- Tickets an Agenten mit passenden Fähigkeiten weiterleiten
+23. **CSAT Ratings** -- Kundenzufriedenheitsumfragen mit tokenbasiertem Zugang
+24. **2FA (TOTP)** -- Zeitbasierte Einmalpasswort-Unterstützung für Agentenkonten
+25. **Guest Access** -- Tokenbasierter Ticketzugriff ohne Authentifizierung
 
 ## Voraussetzungen
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- Eine relationale Datenbank (PostgreSQL, MySQL oder H2 für die Entwicklung)
 
 ## Installation
 
-Add the dependency to your `build.gradle.kts`:
+Fügen Sie die Abhängigkeit zu Ihrer `build.gradle.kts` hinzu:
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+Oder `pom.xml`:
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## Konfiguration
 
-Add to your `application.properties` or `application.yml`:
+Fügen Sie dies zu Ihrer `application.properties` oder `application.yml` hinzu:
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## Datenbank-Einrichtung
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Flyway-Migrationen sind enthalten und werden automatisch ausgeführt. Die Migration erstellt alle Tabellen mit dem Präfix `escalated_` und legt Standardrollen und -berechtigungen an.
 
-## API Endpoints
+## API-Endpunkte
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| Methode | Pfad | Beschreibung |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | Tickets auflisten (paginiert, filterbar) |
+| POST | `/tickets` | Ticket erstellen |
+| GET | `/tickets/{id}` | Ticket abrufen |
+| PUT | `/tickets/{id}` | Ticket aktualisieren |
+| POST | `/tickets/{id}/assign` | Ticket zuweisen |
+| POST | `/tickets/{id}/status` | Status ändern |
+| POST | `/tickets/{id}/snooze` | Ticket schlummern lassen |
+| POST | `/tickets/{id}/merge` | Tickets zusammenführen |
+| POST | `/tickets/{id}/split` | Ticket aufteilen |
+| DELETE | `/tickets/{id}` | Ticket löschen |
+| GET/POST | `/departments` | Abteilungen verwalten |
+| GET/POST | `/agents` | Agenten verwalten |
+| GET/POST | `/webhooks` | Webhooks verwalten |
+| GET/POST | `/roles` | Rollen verwalten |
+| GET/POST | `/custom-fields` | Benutzerdefinierte Felder verwalten |
+| GET/POST | `/settings` | Einstellungen verwalten |
+| GET | `/audit-logs` | Audit-Logs anzeigen |
+| POST | `/import/tickets` | Tickets importieren |
+| GET/POST | `/kb/categories` | KB-Kategorien verwalten |
+| GET/POST | `/kb/articles` | KB-Artikel verwalten |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| Methode | Pfad | Beschreibung |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | Zugewiesene/gefilterte Tickets auflisten |
+| GET | `/tickets/{id}` | Ticket anzeigen |
+| POST | `/tickets/{id}/replies` | Antwort hinzufügen |
+| POST | `/tickets/{id}/macro/{macroId}` | Makro anwenden |
+| POST | `/tickets/{id}/side-conversations` | Nebenkonversation erstellen |
+| POST | `/tickets/{id}/links` | Tickets verknüpfen |
+| GET/POST | `/saved-views` | Gespeicherte Ansichten verwalten |
+| GET/POST | `/canned-responses` | Vorgefertigte Antworten verwalten |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| Methode | Pfad | Beschreibung |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | Kundentickets anzeigen |
+| POST | `/tickets` | Ticket erstellen |
+| POST | `/tickets/{id}/replies` | Antwort hinzufügen |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| Methode | Pfad | Beschreibung |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | Ticket erstellen (öffentlich) |
+| GET | `/tickets/{token}` | Ticket per Gast-Token anzeigen |
+| POST | `/tickets/{token}/replies` | Per Gast-Token antworten |
+| GET | `/kb/search?query=` | Wissensdatenbank durchsuchen |
+| POST | `/csat/{token}` | Zufriedenheitsbewertung abgeben |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| Methode | Pfad | Beschreibung |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | Ticket anzeigen |
+| GET | `/tickets/{token}/replies` | Antworten anzeigen |
+| POST | `/tickets/{token}/replies` | Antwort hinzufügen |
 
-## Architecture
+## Architektur
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              Auto-Konfiguration, Eigenschaften, WebSocket-Konfiguration
+  models/              JPA-Entitäten mit vollständigen Beziehungen
+  repositories/        Spring Data JPA-Repositories
+  services/            Geschäftslogik (transaktional)
   controllers/
     admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    agent/             Agenten REST API
+    customer/          Kunden REST API
+    widget/            Öffentliche Widget-API
+  events/              Spring-Anwendungsereignisse + Webhook-Listener
+  security/            API-Token-Auth-Filter, Sicherheitskonfiguration, 2FA
+  scheduling/          @Scheduled-Aufgaben (Schlummern, SLA, Automatisierungen)
 ```
 
-## Authentication
+## Authentifizierung
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+API-Endpunkte verwenden Bearer-Token-Authentifizierung. Erstellen Sie Tokens über die Admin-API:
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+Die Antwort enthält den Klartext-Token (wird nur einmal angezeigt). Verwenden Sie ihn in nachfolgenden Anfragen:
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (Echtzeit)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+Aktivieren mit `escalated.broadcasting.enabled=true`. Verbinden Sie sich mit `/escalated/ws` über SockJS/STOMP.
 
-## Development
+## Entwicklung
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## Lizenz
 
-MIT License. See [LICENSE](LICENSE) for details.
+MIT-Lizenz. Siehe [LICENSE](LICENSE) für Details.

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Un sistema de mesa de ayuda integrable para aplicaciones Spring Boot. Agregue un escritorio de soporte completo a cualquier aplicación Java con una sola dependencia.
 
 ## Características
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- Gestión completa del ciclo de vida con estados, prioridades y asignaciones
+2. **SLA Policies** -- SLAs configurables con soporte de horario comercial y calendarios de días festivos
+3. **Automations** -- Reglas basadas en tiempo para cierre automático de tickets resueltos y asignación automática
+4. **Escalation Rules** -- Escalamiento automático por incumplimiento de SLA con reasignación y notificaciones
+5. **Macros & Canned Responses** -- Acciones predefinidas y plantillas de respuesta para agentes
+6. **Custom Fields** -- Datos de tickets extensibles con múltiples tipos de campos
+7. **Knowledge Base** -- Artículos y categorías con búsqueda, conteo de vistas y comentarios
+8. **Webhooks** -- Entrega de webhooks firmados con HMAC con lógica de reintentos
+9. **API Tokens** -- Autenticación con token hasheado SHA-256 para acceso a la API
+10. **Roles & Permissions** -- Control de acceso granular basado en roles
+11. **Audit Logging** -- Registro de auditoría completo para todas las acciones
+12. **Import System** -- Importación masiva de tickets desde datos estructurados
+13. **Side Conversations** -- Conversaciones privadas con hilos dentro de los tickets
+14. **Ticket Merging & Linking** -- Fusionar tickets duplicados y vincular los relacionados
+15. **Ticket Splitting** -- Dividir tickets complejos en problemas separados
+16. **Ticket Snooze** -- Posponer tickets con despertar automático mediante `@Scheduled`
+17. **Email Threading** -- Plantillas de correo HTML con marca mediante Thymeleaf con encadenamiento correcto de Message-ID
+18. **Saved Views** -- Vistas de tickets personalizadas filtradas/ordenadas por agente
+19. **Widget API** -- Endpoints REST públicos para incrustar un widget de soporte
+20. **Real-time Broadcasting** -- WebSocket mediante STOMP/SockJS (opcional)
+21. **Capacity Management** -- Seguimiento y aplicación de límites de carga de trabajo de agentes
+22. **Skill-based Routing** -- Dirigir tickets a agentes con habilidades coincidentes
+23. **CSAT Ratings** -- Encuestas de satisfacción del cliente con acceso basado en token
+24. **2FA (TOTP)** -- Soporte de contraseña de un solo uso basada en tiempo para cuentas de agentes
+25. **Guest Access** -- Acceso a tickets basado en token sin autenticación
 
 ## Requisitos
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- Una base de datos relacional (PostgreSQL, MySQL o H2 para desarrollo)
 
 ## Instalación
 
-Add the dependency to your `build.gradle.kts`:
+Agregue la dependencia a su `build.gradle.kts`:
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+O `pom.xml`:
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## Configuración
 
-Add to your `application.properties` or `application.yml`:
+Agregue a su `application.properties` o `application.yml`:
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## Configuración de base de datos
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Las migraciones de Flyway están incluidas y se ejecutan automáticamente. La migración crea todas las tablas con el prefijo `escalated_` y establece roles y permisos predeterminados.
 
-## API Endpoints
+## Endpoints de API
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| Método | Ruta | Descripción |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | Listar tickets (paginado, filtrable) |
+| POST | `/tickets` | Crear ticket |
+| GET | `/tickets/{id}` | Obtener ticket |
+| PUT | `/tickets/{id}` | Actualizar ticket |
+| POST | `/tickets/{id}/assign` | Asignar ticket |
+| POST | `/tickets/{id}/status` | Cambiar estado |
+| POST | `/tickets/{id}/snooze` | Posponer ticket |
+| POST | `/tickets/{id}/merge` | Fusionar tickets |
+| POST | `/tickets/{id}/split` | Dividir ticket |
+| DELETE | `/tickets/{id}` | Eliminar ticket |
+| GET/POST | `/departments` | Gestionar departamentos |
+| GET/POST | `/agents` | Gestionar agentes |
+| GET/POST | `/webhooks` | Gestionar webhooks |
+| GET/POST | `/roles` | Gestionar roles |
+| GET/POST | `/custom-fields` | Gestionar campos personalizados |
+| GET/POST | `/settings` | Gestionar configuraciones |
+| GET | `/audit-logs` | Ver registros de auditoría |
+| POST | `/import/tickets` | Importar tickets |
+| GET/POST | `/kb/categories` | Gestionar categorías de KB |
+| GET/POST | `/kb/articles` | Gestionar artículos de KB |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| Método | Ruta | Descripción |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | Listar tickets asignados/filtrados |
+| GET | `/tickets/{id}` | Ver ticket |
+| POST | `/tickets/{id}/replies` | Agregar respuesta |
+| POST | `/tickets/{id}/macro/{macroId}` | Aplicar macro |
+| POST | `/tickets/{id}/side-conversations` | Crear conversación lateral |
+| POST | `/tickets/{id}/links` | Vincular tickets |
+| GET/POST | `/saved-views` | Gestionar vistas guardadas |
+| GET/POST | `/canned-responses` | Gestionar respuestas predefinidas |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| Método | Ruta | Descripción |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | Listar tickets del cliente |
+| POST | `/tickets` | Crear ticket |
+| POST | `/tickets/{id}/replies` | Agregar respuesta |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| Método | Ruta | Descripción |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | Crear ticket (público) |
+| GET | `/tickets/{token}` | Ver ticket por token de invitado |
+| POST | `/tickets/{token}/replies` | Responder mediante token de invitado |
+| GET | `/kb/search?query=` | Buscar en la base de conocimientos |
+| POST | `/csat/{token}` | Enviar calificación de satisfacción |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| Método | Ruta | Descripción |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | Ver ticket |
+| GET | `/tickets/{token}/replies` | Ver respuestas |
+| POST | `/tickets/{token}/replies` | Agregar respuesta |
 
-## Architecture
+## Arquitectura
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              Auto-configuración, propiedades, configuración de WebSocket
+  models/              Entidades JPA con relaciones completas
+  repositories/        Repositorios Spring Data JPA
+  services/            Lógica de negocio (transaccional)
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             API REST de administrador
+    agent/             API REST de agente
+    customer/          API REST de cliente
+    widget/            API pública del widget
+  events/              Eventos de aplicación Spring + listener de webhooks
+  security/            Filtro de autenticación de token API, configuración de seguridad, 2FA
+  scheduling/          Tareas @Scheduled (posponer, SLA, automatizaciones)
 ```
 
-## Authentication
+## Autenticación
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+Los endpoints de API usan autenticación con token Bearer. Cree tokens a través de la API de administrador:
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+La respuesta incluye el token en texto plano (se muestra solo una vez). Úselo en solicitudes posteriores:
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (Tiempo real)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+Habilitar con `escalated.broadcasting.enabled=true`. Conéctese a `/escalated/ws` mediante SockJS/STOMP.
 
-## Development
+## Desarrollo
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## Licencia
 
-MIT License. See [LICENSE](LICENSE) for details.
+Licencia MIT. Consulte [LICENSE](LICENSE) para más detalles.

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Un système de helpdesk intégrable pour les applications Spring Boot. Ajoutez un bureau d'assistance complet à toute application Java avec une seule dépendance.
 
 ## Fonctionnalités
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- Gestion complète du cycle de vie avec statuts, priorités et affectations
+2. **SLA Policies** -- SLAs configurables avec support des heures ouvrables et calendriers de jours fériés
+3. **Automations** -- Règles temporelles pour la fermeture automatique des tickets résolus et l'affectation automatique
+4. **Escalation Rules** -- Escalade automatique en cas de violation de SLA avec réaffectation et notifications
+5. **Macros & Canned Responses** -- Actions prédéfinies et modèles de réponse pour les agents
+6. **Custom Fields** -- Données de tickets extensibles avec plusieurs types de champs
+7. **Knowledge Base** -- Articles et catégories avec recherche, compteur de vues et retours
+8. **Webhooks** -- Livraison de webhooks signés HMAC avec logique de réessai
+9. **API Tokens** -- Authentification par jeton haché SHA-256 pour l'accès à l'API
+10. **Roles & Permissions** -- Contrôle d'accès granulaire basé sur les rôles
+11. **Audit Logging** -- Piste d'audit complète pour toutes les actions
+12. **Import System** -- Importation en masse de tickets à partir de données structurées
+13. **Side Conversations** -- Conversations privées avec fils de discussion au sein des tickets
+14. **Ticket Merging & Linking** -- Fusionner les tickets en double et lier les tickets associés
+15. **Ticket Splitting** -- Diviser les tickets complexes en problèmes séparés
+16. **Ticket Snooze** -- Mettre en veille les tickets avec réveil automatique via `@Scheduled`
+17. **Email Threading** -- Modèles d'e-mail HTML personnalisés via Thymeleaf avec chaînage correct de Message-ID
+18. **Saved Views** -- Vues de tickets personnalisées filtrées/triées par agent
+19. **Widget API** -- Points de terminaison REST publics pour intégrer un widget d'assistance
+20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (optionnel)
+21. **Capacity Management** -- Suivi et application des limites de charge de travail des agents
+22. **Skill-based Routing** -- Acheminer les tickets vers les agents ayant les compétences correspondantes
+23. **CSAT Ratings** -- Enquêtes de satisfaction client avec accès par jeton
+24. **2FA (TOTP)** -- Support de mot de passe à usage unique basé sur le temps pour les comptes agents
+25. **Guest Access** -- Accès aux tickets par jeton sans authentification
 
 ## Prérequis
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- Une base de données relationnelle (PostgreSQL, MySQL ou H2 pour le développement)
 
 ## Installation
 
-Add the dependency to your `build.gradle.kts`:
+Ajoutez la dépendance à votre `build.gradle.kts` :
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+Ou `pom.xml` :
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## Configuration
 
-Add to your `application.properties` or `application.yml`:
+Ajoutez à votre `application.properties` ou `application.yml` :
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## Configuration de la base de données
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Les migrations Flyway sont incluses et s'exécutent automatiquement. La migration crée toutes les tables préfixées par `escalated_` et initialise les rôles et permissions par défaut.
 
-## API Endpoints
+## Points de terminaison API
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| Méthode | Chemin | Description |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | Lister les tickets (paginé, filtrable) |
+| POST | `/tickets` | Créer un ticket |
+| GET | `/tickets/{id}` | Obtenir un ticket |
+| PUT | `/tickets/{id}` | Mettre à jour un ticket |
+| POST | `/tickets/{id}/assign` | Affecter un ticket |
+| POST | `/tickets/{id}/status` | Changer le statut |
+| POST | `/tickets/{id}/snooze` | Mettre en veille un ticket |
+| POST | `/tickets/{id}/merge` | Fusionner des tickets |
+| POST | `/tickets/{id}/split` | Diviser un ticket |
+| DELETE | `/tickets/{id}` | Supprimer un ticket |
+| GET/POST | `/departments` | Gérer les départements |
+| GET/POST | `/agents` | Gérer les agents |
+| GET/POST | `/webhooks` | Gérer les webhooks |
+| GET/POST | `/roles` | Gérer les rôles |
+| GET/POST | `/custom-fields` | Gérer les champs personnalisés |
+| GET/POST | `/settings` | Gérer les paramètres |
+| GET | `/audit-logs` | Voir les journaux d'audit |
+| POST | `/import/tickets` | Importer des tickets |
+| GET/POST | `/kb/categories` | Gérer les catégories KB |
+| GET/POST | `/kb/articles` | Gérer les articles KB |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| Méthode | Chemin | Description |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | Lister les tickets assignés/filtrés |
+| GET | `/tickets/{id}` | Voir le ticket |
+| POST | `/tickets/{id}/replies` | Ajouter une réponse |
+| POST | `/tickets/{id}/macro/{macroId}` | Appliquer une macro |
+| POST | `/tickets/{id}/side-conversations` | Créer une conversation parallèle |
+| POST | `/tickets/{id}/links` | Lier des tickets |
+| GET/POST | `/saved-views` | Gérer les vues enregistrées |
+| GET/POST | `/canned-responses` | Gérer les réponses prédéfinies |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| Méthode | Chemin | Description |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | Lister les tickets client |
+| POST | `/tickets` | Créer un ticket |
+| POST | `/tickets/{id}/replies` | Ajouter une réponse |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| Méthode | Chemin | Description |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | Créer un ticket (public) |
+| GET | `/tickets/{token}` | Voir le ticket par jeton d'invité |
+| POST | `/tickets/{token}/replies` | Répondre via jeton d'invité |
+| GET | `/kb/search?query=` | Rechercher dans la base de connaissances |
+| POST | `/csat/{token}` | Soumettre une évaluation de satisfaction |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| Méthode | Chemin | Description |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | Voir le ticket |
+| GET | `/tickets/{token}/replies` | Voir les réponses |
+| POST | `/tickets/{token}/replies` | Ajouter une réponse |
 
 ## Architecture
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              Auto-configuration, propriétés, configuration WebSocket
+  models/              Entités JPA avec relations complètes
+  repositories/        Dépôts Spring Data JPA
+  services/            Logique métier (transactionnelle)
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             API REST administrateur
+    agent/             API REST agent
+    customer/          API REST client
+    widget/            API widget publique
+  events/              Événements d'application Spring + écouteur de webhooks
+  security/            Filtre d'authentification par jeton API, configuration de sécurité, 2FA
+  scheduling/          @Scheduled tâches (veille, SLA, automatisations)
 ```
 
-## Authentication
+## Authentification
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+Les points de terminaison API utilisent l'authentification par jeton Bearer. Créez des jetons via l'API administrateur :
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+La réponse inclut le jeton en texte clair (affiché une seule fois). Utilisez-le dans les requêtes suivantes :
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (Temps réel)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+Activez avec `escalated.broadcasting.enabled=true`. Connectez-vous à `/escalated/ws` via SockJS/STOMP.
 
-## Development
+## Développement
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## Licence
 
-MIT License. See [LICENSE](LICENSE) for details.
+Licence MIT. Voir [LICENSE](LICENSE) pour les détails.

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Un sistema di helpdesk integrabile per applicazioni Spring Boot. Aggiungi un desk di supporto completo a qualsiasi applicazione Java con una singola dipendenza.
 
 ## Funzionalità
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- Gestione completa del ciclo di vita con stati, priorità e assegnazioni
+2. **SLA Policies** -- SLA configurabili con supporto orari lavorativi e calendari festività
+3. **Automations** -- Regole temporali per la chiusura automatica dei ticket risolti e assegnazione automatica
+4. **Escalation Rules** -- Escalation automatica in caso di violazione SLA con riassegnazione e notifiche
+5. **Macros & Canned Responses** -- Azioni predefinite e modelli di risposta per gli agenti
+6. **Custom Fields** -- Dati ticket estensibili con molteplici tipi di campo
+7. **Knowledge Base** -- Articoli e categorie con ricerca, conteggio visualizzazioni e feedback
+8. **Webhooks** -- Consegna webhook firmati HMAC con logica di ripetizione
+9. **API Tokens** -- Autenticazione con token hashato SHA-256 per accesso API
+10. **Roles & Permissions** -- Controllo degli accessi granulare basato sui ruoli
+11. **Audit Logging** -- Traccia di audit completa per tutte le azioni
+12. **Import System** -- Importazione massiva di ticket da dati strutturati
+13. **Side Conversations** -- Conversazioni private con thread all'interno dei ticket
+14. **Ticket Merging & Linking** -- Unire ticket duplicati e collegare quelli correlati
+15. **Ticket Splitting** -- Dividere ticket complessi in problemi separati
+16. **Ticket Snooze** -- Posticipare ticket con risveglio automatico tramite `@Scheduled`
+17. **Email Threading** -- Modelli email HTML personalizzati tramite Thymeleaf con threading corretto di Message-ID
+18. **Saved Views** -- Viste ticket personalizzate filtrate/ordinate per agente
+19. **Widget API** -- Endpoint REST pubblici per incorporare un widget di supporto
+20. **Real-time Broadcasting** -- WebSocket tramite STOMP/SockJS (opzionale)
+21. **Capacity Management** -- Monitoraggio e applicazione dei limiti di carico di lavoro degli agenti
+22. **Skill-based Routing** -- Instradamento ticket verso agenti con competenze corrispondenti
+23. **CSAT Ratings** -- Sondaggi di soddisfazione clienti con accesso basato su token
+24. **2FA (TOTP)** -- Supporto password monouso basata sul tempo per account agente
+25. **Guest Access** -- Accesso ai ticket basato su token senza autenticazione
 
 ## Requisiti
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- Un database relazionale (PostgreSQL, MySQL o H2 per lo sviluppo)
 
 ## Installazione
 
-Add the dependency to your `build.gradle.kts`:
+Aggiungi la dipendenza al tuo `build.gradle.kts`:
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+O `pom.xml`:
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## Configurazione
 
-Add to your `application.properties` or `application.yml`:
+Aggiungi al tuo `application.properties` o `application.yml`:
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## Configurazione del database
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Le migrazioni Flyway sono incluse e vengono eseguite automaticamente. La migrazione crea tutte le tabelle con il prefisso `escalated_` e inizializza ruoli e permessi predefiniti.
 
-## API Endpoints
+## Endpoint API
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| Metodo | Percorso | Descrizione |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | Elenco ticket (paginato, filtrabile) |
+| POST | `/tickets` | Crea ticket |
+| GET | `/tickets/{id}` | Ottieni ticket |
+| PUT | `/tickets/{id}` | Aggiorna ticket |
+| POST | `/tickets/{id}/assign` | Assegna ticket |
+| POST | `/tickets/{id}/status` | Cambia stato |
+| POST | `/tickets/{id}/snooze` | Posticipa ticket |
+| POST | `/tickets/{id}/merge` | Unisci ticket |
+| POST | `/tickets/{id}/split` | Dividi ticket |
+| DELETE | `/tickets/{id}` | Elimina ticket |
+| GET/POST | `/departments` | Gestisci dipartimenti |
+| GET/POST | `/agents` | Gestisci agenti |
+| GET/POST | `/webhooks` | Gestisci webhook |
+| GET/POST | `/roles` | Gestisci ruoli |
+| GET/POST | `/custom-fields` | Gestisci campi personalizzati |
+| GET/POST | `/settings` | Gestisci impostazioni |
+| GET | `/audit-logs` | Visualizza log di audit |
+| POST | `/import/tickets` | Importa ticket |
+| GET/POST | `/kb/categories` | Gestisci categorie KB |
+| GET/POST | `/kb/articles` | Gestisci articoli KB |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| Metodo | Percorso | Descrizione |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | Elenco ticket assegnati/filtrati |
+| GET | `/tickets/{id}` | Visualizza ticket |
+| POST | `/tickets/{id}/replies` | Aggiungi risposta |
+| POST | `/tickets/{id}/macro/{macroId}` | Applica macro |
+| POST | `/tickets/{id}/side-conversations` | Crea conversazione laterale |
+| POST | `/tickets/{id}/links` | Collega ticket |
+| GET/POST | `/saved-views` | Gestisci viste salvate |
+| GET/POST | `/canned-responses` | Gestisci risposte predefinite |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| Metodo | Percorso | Descrizione |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | Elenco ticket del cliente |
+| POST | `/tickets` | Crea ticket |
+| POST | `/tickets/{id}/replies` | Aggiungi risposta |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| Metodo | Percorso | Descrizione |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | Crea ticket (pubblico) |
+| GET | `/tickets/{token}` | Visualizza ticket tramite token ospite |
+| POST | `/tickets/{token}/replies` | Rispondi tramite token ospite |
+| GET | `/kb/search?query=` | Cerca nella base di conoscenza |
+| POST | `/csat/{token}` | Invia valutazione soddisfazione |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| Metodo | Percorso | Descrizione |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | Visualizza ticket |
+| GET | `/tickets/{token}/replies` | Visualizza risposte |
+| POST | `/tickets/{token}/replies` | Aggiungi risposta |
 
-## Architecture
+## Architettura
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              Auto-configurazione, proprietà, configurazione WebSocket
+  models/              Entità JPA con relazioni complete
+  repositories/        Repository Spring Data JPA
+  services/            Logica di business (transazionale)
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             API REST amministratore
+    agent/             API REST agente
+    customer/          API REST cliente
+    widget/            API widget pubblica
+  events/              Eventi applicazione Spring + listener webhook
+  security/            Filtro autenticazione token API, configurazione sicurezza, 2FA
+  scheduling/          Attività @Scheduled (posticipo, SLA, automatizzazioni)
 ```
 
-## Authentication
+## Autenticazione
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+Gli endpoint API utilizzano l'autenticazione con token Bearer. Crea token tramite l'API amministratore:
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+La risposta include il token in testo semplice (mostrato solo una volta). Usalo nelle richieste successive:
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (Tempo reale)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+Attiva con `escalated.broadcasting.enabled=true`. Connettiti a `/escalated/ws` tramite SockJS/STOMP.
 
-## Development
+## Sviluppo
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## Licenza
 
-MIT License. See [LICENSE](LICENSE) for details.
+Licenza MIT. Vedi [LICENSE](LICENSE) per i dettagli.

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Spring Bootアプリケーション向けの組み込み可能なヘルプデスクシステム。単一の依存関係でフル機能のサポートデスクを任意のJavaアプリケーションに追加できます。
 
 ## 機能
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- ステータス、優先度、割り当てによる完全なライフサイクル管理
+2. **SLA Policies** -- 営業時間サポートと休日カレンダーを備えた設定可能なSLA
+3. **Automations** -- 解決済みチケットの自動クローズと自動割り当てのための時間ベースのルール
+4. **Escalation Rules** -- SLA違反時の再割り当てと通知による自動エスカレーション
+5. **Macros & Canned Responses** -- エージェント向けの定義済みアクションと応答テンプレート
+6. **Custom Fields** -- 複数のフィールドタイプによる拡張可能なチケットデータ
+7. **Knowledge Base** -- 検索、閲覧数、フィードバック付きの記事とカテゴリ
+8. **Webhooks** -- リトライロジック付きHMAC署名Webhook配信
+9. **API Tokens** -- APIアクセス用のSHA-256ハッシュトークン認証
+10. **Roles & Permissions** -- きめ細かなロールベースのアクセス制御
+11. **Audit Logging** -- すべてのアクションの完全な監査証跡
+12. **Import System** -- 構造化データからのチケット一括インポート
+13. **Side Conversations** -- チケット内のプライベートスレッド会話
+14. **Ticket Merging & Linking** -- 重複チケットの統合と関連チケットのリンク
+15. **Ticket Splitting** -- 複雑なチケットを個別の問題に分割
+16. **Ticket Snooze** -- `@Scheduled`による自動ウェイクアップ付きチケットスヌーズ
+17. **Email Threading** -- ThymeleafによるブランドHTMLメールテンプレートと正しいMessage-IDスレッディング
+18. **Saved Views** -- エージェントごとのカスタムフィルター/ソート済みチケットビュー
+19. **Widget API** -- サポートウィジェット埋め込み用のパブリックRESTエンドポイント
+20. **Real-time Broadcasting** -- STOMP/SockJS経由のWebSocket（オプトイン）
+21. **Capacity Management** -- エージェントのワークロード制限の追跡と適用
+22. **Skill-based Routing** -- マッチするスキルを持つエージェントへのチケットルーティング
+23. **CSAT Ratings** -- トークンベースのアクセスによる顧客満足度調査
+24. **2FA (TOTP)** -- エージェントアカウント用の時間ベースワンタイムパスワードサポート
+25. **Guest Access** -- 認証不要のトークンベースチケットアクセス
 
 ## 要件
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- リレーショナルデータベース（PostgreSQL、MySQL、または開発用H2）
 
 ## インストール
 
-Add the dependency to your `build.gradle.kts`:
+`build.gradle.kts`に依存関係を追加します：
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+または`pom.xml`：
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## 設定
 
-Add to your `application.properties` or `application.yml`:
+`application.properties`または`application.yml`に追加します：
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## データベースセットアップ
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Flywayマイグレーションが含まれており、自動的に実行されます。マイグレーションは`escalated_`プレフィックス付きのすべてのテーブルを作成し、デフォルトのロールと権限をシードします。
 
-## API Endpoints
+## APIエンドポイント
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| メソッド | パス | 説明 |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | チケット一覧（ページネーション、フィルター可能） |
+| POST | `/tickets` | チケット作成 |
+| GET | `/tickets/{id}` | チケット取得 |
+| PUT | `/tickets/{id}` | チケット更新 |
+| POST | `/tickets/{id}/assign` | チケット割り当て |
+| POST | `/tickets/{id}/status` | ステータス変更 |
+| POST | `/tickets/{id}/snooze` | チケットスヌーズ |
+| POST | `/tickets/{id}/merge` | チケット統合 |
+| POST | `/tickets/{id}/split` | チケット分割 |
+| DELETE | `/tickets/{id}` | チケット削除 |
+| GET/POST | `/departments` | 部門管理 |
+| GET/POST | `/agents` | エージェント管理 |
+| GET/POST | `/webhooks` | Webhook管理 |
+| GET/POST | `/roles` | ロール管理 |
+| GET/POST | `/custom-fields` | カスタムフィールド管理 |
+| GET/POST | `/settings` | 設定管理 |
+| GET | `/audit-logs` | 監査ログ表示 |
+| POST | `/import/tickets` | チケットインポート |
+| GET/POST | `/kb/categories` | KBカテゴリ管理 |
+| GET/POST | `/kb/articles` | KB記事管理 |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| メソッド | パス | 説明 |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | 割り当て済み/フィルター済みチケット一覧 |
+| GET | `/tickets/{id}` | チケット表示 |
+| POST | `/tickets/{id}/replies` | 返信追加 |
+| POST | `/tickets/{id}/macro/{macroId}` | マクロ適用 |
+| POST | `/tickets/{id}/side-conversations` | サイドカンバセーション作成 |
+| POST | `/tickets/{id}/links` | チケットリンク |
+| GET/POST | `/saved-views` | 保存済みビュー管理 |
+| GET/POST | `/canned-responses` | 定型応答管理 |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| メソッド | パス | 説明 |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | 顧客チケット一覧 |
+| POST | `/tickets` | チケット作成 |
+| POST | `/tickets/{id}/replies` | 返信追加 |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| メソッド | パス | 説明 |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | チケット作成（公開） |
+| GET | `/tickets/{token}` | ゲストトークンでチケット表示 |
+| POST | `/tickets/{token}/replies` | ゲストトークンで返信 |
+| GET | `/kb/search?query=` | ナレッジベース検索 |
+| POST | `/csat/{token}` | 満足度評価送信 |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| メソッド | パス | 説明 |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | チケット表示 |
+| GET | `/tickets/{token}/replies` | 返信表示 |
+| POST | `/tickets/{token}/replies` | 返信追加 |
 
-## Architecture
+## アーキテクチャ
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              自動設定、プロパティ、WebSocket設定
+  models/              完全なリレーション付きJPAエンティティ
+  repositories/        Spring Data JPAリポジトリ
+  services/            ビジネスロジック（トランザクション）
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             管理者REST API
+    agent/             エージェントREST API
+    customer/          顧客REST API
+    widget/            公開ウィジェットAPI
+  events/              Springアプリケーションイベント + Webhookリスナー
+  security/            APIトークン認証フィルター、セキュリティ設定、2FA
+  scheduling/          @Scheduledタスク（スヌーズ、SLA、自動化）
 ```
 
-## Authentication
+## 認証
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+APIエンドポイントはBearerトークン認証を使用します。管理者APIでトークンを作成します：
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+レスポンスにはプレーンテキストのトークンが含まれます（一度だけ表示）。後続のリクエストで使用します：
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket（リアルタイム）
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+`escalated.broadcasting.enabled=true`で有効化します。SockJS/STOMP経由で`/escalated/ws`に接続します。
 
-## Development
+## 開発
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## ライセンス
 
-MIT License. See [LICENSE](LICENSE) for details.
+MITライセンス。詳細は[LICENSE](LICENSE)を参照してください。

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Spring Boot 애플리케이션을 위한 내장 가능한 헬프데스크 시스템. 단일 종속성으로 모든 Java 애플리케이션에 완전한 기능의 지원 데스크를 추가합니다.
 
 ## 기능
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- 상태, 우선순위, 할당을 통한 전체 라이프사이클 관리
+2. **SLA Policies** -- 영업 시간 지원 및 휴일 캘린더를 갖춘 구성 가능한 SLA
+3. **Automations** -- 해결된 티켓 자동 닫기 및 자동 할당을 위한 시간 기반 규칙
+4. **Escalation Rules** -- SLA 위반 시 재할당 및 알림을 통한 자동 에스컬레이션
+5. **Macros & Canned Responses** -- 에이전트를 위한 사전 정의된 작업 및 응답 템플릿
+6. **Custom Fields** -- 다양한 필드 유형의 확장 가능한 티켓 데이터
+7. **Knowledge Base** -- 검색, 조회수, 피드백이 포함된 기사 및 카테고리
+8. **Webhooks** -- 재시도 로직을 갖춘 HMAC 서명 Webhook 전달
+9. **API Tokens** -- API 접근을 위한 SHA-256 해시 토큰 인증
+10. **Roles & Permissions** -- 세분화된 역할 기반 접근 제어
+11. **Audit Logging** -- 모든 작업에 대한 완전한 감사 추적
+12. **Import System** -- 구조화된 데이터에서 티켓 대량 가져오기
+13. **Side Conversations** -- 티켓 내 비공개 스레드 대화
+14. **Ticket Merging & Linking** -- 중복 티켓 병합 및 관련 티켓 연결
+15. **Ticket Splitting** -- 복잡한 티켓을 별도의 이슈로 분할
+16. **Ticket Snooze** -- `@Scheduled`를 통한 자동 깨우기 티켓 스누즈
+17. **Email Threading** -- Thymeleaf를 통한 브랜드 HTML 이메일 템플릿과 올바른 Message-ID 스레딩
+18. **Saved Views** -- 에이전트별 사용자 정의 필터/정렬 티켓 뷰
+19. **Widget API** -- 지원 위젯 임베딩을 위한 공개 REST 엔드포인트
+20. **Real-time Broadcasting** -- STOMP/SockJS를 통한 WebSocket (옵트인)
+21. **Capacity Management** -- 에이전트 워크로드 제한 추적 및 적용
+22. **Skill-based Routing** -- 매칭되는 스킬을 가진 에이전트에게 티켓 라우팅
+23. **CSAT Ratings** -- 토큰 기반 접근을 통한 고객 만족도 설문조사
+24. **2FA (TOTP)** -- 에이전트 계정을 위한 시간 기반 일회용 비밀번호 지원
+25. **Guest Access** -- 인증 없는 토큰 기반 티켓 접근
 
 ## 요구 사항
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- 관계형 데이터베이스 (PostgreSQL, MySQL 또는 개발용 H2)
 
 ## 설치
 
-Add the dependency to your `build.gradle.kts`:
+`build.gradle.kts`에 종속성을 추가합니다:
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+또는 `pom.xml`:
 
 ```xml
 <dependency>
@@ -71,9 +71,9 @@ Or `pom.xml`:
 </dependency>
 ```
 
-## 설정
+## 구성
 
-Add to your `application.properties` or `application.yml`:
+`application.properties` 또는 `application.yml`에 추가합니다:
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## 데이터베이스 설정
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Flyway 마이그레이션이 포함되어 자동으로 실행됩니다. 마이그레이션은 `escalated_` 접두사가 붙은 모든 테이블을 생성하고 기본 역할과 권한을 시드합니다.
 
-## API Endpoints
+## API 엔드포인트
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| 메서드 | 경로 | 설명 |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | 티켓 목록 (페이지네이션, 필터 가능) |
+| POST | `/tickets` | 티켓 생성 |
+| GET | `/tickets/{id}` | 티켓 조회 |
+| PUT | `/tickets/{id}` | 티켓 수정 |
+| POST | `/tickets/{id}/assign` | 티켓 할당 |
+| POST | `/tickets/{id}/status` | 상태 변경 |
+| POST | `/tickets/{id}/snooze` | 티켓 스누즈 |
+| POST | `/tickets/{id}/merge` | 티켓 병합 |
+| POST | `/tickets/{id}/split` | 티켓 분할 |
+| DELETE | `/tickets/{id}` | 티켓 삭제 |
+| GET/POST | `/departments` | 부서 관리 |
+| GET/POST | `/agents` | 에이전트 관리 |
+| GET/POST | `/webhooks` | Webhook 관리 |
+| GET/POST | `/roles` | 역할 관리 |
+| GET/POST | `/custom-fields` | 사용자 정의 필드 관리 |
+| GET/POST | `/settings` | 설정 관리 |
+| GET | `/audit-logs` | 감사 로그 보기 |
+| POST | `/import/tickets` | 티켓 가져오기 |
+| GET/POST | `/kb/categories` | KB 카테고리 관리 |
+| GET/POST | `/kb/articles` | KB 기사 관리 |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| 메서드 | 경로 | 설명 |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | 할당/필터된 티켓 목록 |
+| GET | `/tickets/{id}` | 티켓 보기 |
+| POST | `/tickets/{id}/replies` | 답변 추가 |
+| POST | `/tickets/{id}/macro/{macroId}` | 매크로 적용 |
+| POST | `/tickets/{id}/side-conversations` | 사이드 대화 생성 |
+| POST | `/tickets/{id}/links` | 티켓 연결 |
+| GET/POST | `/saved-views` | 저장된 뷰 관리 |
+| GET/POST | `/canned-responses` | 정형 응답 관리 |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| 메서드 | 경로 | 설명 |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | 고객 티켓 목록 |
+| POST | `/tickets` | 티켓 생성 |
+| POST | `/tickets/{id}/replies` | 답변 추가 |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| 메서드 | 경로 | 설명 |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | 티켓 생성 (공개) |
+| GET | `/tickets/{token}` | 게스트 토큰으로 티켓 보기 |
+| POST | `/tickets/{token}/replies` | 게스트 토큰으로 답변 |
+| GET | `/kb/search?query=` | 지식 베이스 검색 |
+| POST | `/csat/{token}` | 만족도 평가 제출 |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| 메서드 | 경로 | 설명 |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | 티켓 보기 |
+| GET | `/tickets/{token}/replies` | 답변 보기 |
+| POST | `/tickets/{token}/replies` | 답변 추가 |
 
-## Architecture
+## 아키텍처
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              자동 구성, 속성, WebSocket 구성
+  models/              완전한 관계를 가진 JPA 엔티티
+  repositories/        Spring Data JPA 리포지토리
+  services/            비즈니스 로직 (트랜잭션)
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             관리자 REST API
+    agent/             에이전트 REST API
+    customer/          고객 REST API
+    widget/            공개 위젯 API
+  events/              Spring 애플리케이션 이벤트 + Webhook 리스너
+  security/            API 토큰 인증 필터, 보안 구성, 2FA
+  scheduling/          @Scheduled 작업 (스누즈, SLA, 자동화)
 ```
 
-## Authentication
+## 인증
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+API 엔드포인트는 Bearer 토큰 인증을 사용합니다. 관리자 API를 통해 토큰을 생성합니다:
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+응답에는 평문 토큰이 포함됩니다 (한 번만 표시). 후속 요청에서 사용합니다:
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (실시간)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+`escalated.broadcasting.enabled=true`로 활성화합니다. SockJS/STOMP를 통해 `/escalated/ws`에 연결합니다.
 
-## Development
+## 개발
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## 라이선스
 
-MIT License. See [LICENSE](LICENSE) for details.
+MIT 라이선스. 자세한 내용은 [LICENSE](LICENSE)를 참조하세요.

--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Een inbedbaar helpdesksysteem voor Spring Boot-applicaties. Voeg een volledig uitgerust supportbureau toe aan elke Java-applicatie met een enkele afhankelijkheid.
 
 ## Functies
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
+1. **Ticket CRUD** -- Volledig levenscyclusbeheer met statussen, prioriteiten en toewijzingen
+2. **SLA Policies** -- Configureerbare SLA's met ondersteuning voor kantooruren en vakantiekalenders
+3. **Automations** -- Tijdgebaseerde regels voor automatisch sluiten van opgeloste tickets en automatische toewijzing
+4. **Escalation Rules** -- Automatische escalatie bij SLA-schending met hertoewijzing en notificaties
+5. **Macros & Canned Responses** -- Voorgedefinieerde acties en antwoordsjablonen voor agenten
+6. **Custom Fields** -- Uitbreidbare ticketgegevens met meerdere veldtypen
+7. **Knowledge Base** -- Artikelen en categorieën met zoeken, weergavetellers en feedback
+8. **Webhooks** -- HMAC-ondertekende webhook-bezorging met herhalingslogica
+9. **API Tokens** -- SHA-256 gehashte tokenauthenticatie voor API-toegang
+10. **Roles & Permissions** -- Gedetailleerde rolgebaseerde toegangscontrole
+11. **Audit Logging** -- Volledige audit trail voor alle acties
+12. **Import System** -- Bulk import van tickets uit gestructureerde gegevens
+13. **Side Conversations** -- Privé thread-gesprekken binnen tickets
+14. **Ticket Merging & Linking** -- Dubbele tickets samenvoegen en gerelateerde koppelen
+15. **Ticket Splitting** -- Complexe tickets opsplitsen in afzonderlijke problemen
+16. **Ticket Snooze** -- Tickets snoozen met automatisch wekken via `@Scheduled`
+17. **Email Threading** -- Merkgebonden HTML e-mailsjablonen via Thymeleaf met correcte Message-ID-threading
+18. **Saved Views** -- Aangepaste gefilterde/gesorteerde ticketweergaven per agent
+19. **Widget API** -- Openbare REST-endpoints voor het inbedden van een supportwidget
 20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+21. **Capacity Management** -- Werkbelastingslimieten van agenten bijhouden en afdwingen
+22. **Skill-based Routing** -- Tickets routeren naar agenten met overeenkomende vaardigheden
+23. **CSAT Ratings** -- Klanttevredenheidsonderzoeken met tokengebaseerde toegang
+24. **2FA (TOTP)** -- Tijdgebaseerde eenmalige wachtwoordondersteuning voor agentaccounts
+25. **Guest Access** -- Tokengebaseerde tickettoegang zonder authenticatie
 
 ## Vereisten
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- Een relationele database (PostgreSQL, MySQL of H2 voor ontwikkeling)
 
 ## Installatie
 
-Add the dependency to your `build.gradle.kts`:
+Voeg de afhankelijkheid toe aan uw `build.gradle.kts`:
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+Of `pom.xml`:
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## Configuratie
 
-Add to your `application.properties` or `application.yml`:
+Voeg toe aan uw `application.properties` of `application.yml`:
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## Database-installatie
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Flyway-migraties zijn inbegrepen en worden automatisch uitgevoerd. De migratie maakt alle tabellen aan met het voorvoegsel `escalated_` en vult standaardrollen en -machtigingen in.
 
-## API Endpoints
+## API-endpoints
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| Methode | Pad | Beschrijving |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | Tickets weergeven (gepagineerd, filterbaar) |
+| POST | `/tickets` | Ticket aanmaken |
+| GET | `/tickets/{id}` | Ticket ophalen |
+| PUT | `/tickets/{id}` | Ticket bijwerken |
+| POST | `/tickets/{id}/assign` | Ticket toewijzen |
+| POST | `/tickets/{id}/status` | Status wijzigen |
+| POST | `/tickets/{id}/snooze` | Ticket snoozen |
+| POST | `/tickets/{id}/merge` | Tickets samenvoegen |
+| POST | `/tickets/{id}/split` | Ticket opsplitsen |
+| DELETE | `/tickets/{id}` | Ticket verwijderen |
+| GET/POST | `/departments` | Afdelingen beheren |
+| GET/POST | `/agents` | Agenten beheren |
+| GET/POST | `/webhooks` | Webhooks beheren |
+| GET/POST | `/roles` | Rollen beheren |
+| GET/POST | `/custom-fields` | Aangepaste velden beheren |
+| GET/POST | `/settings` | Instellingen beheren |
+| GET | `/audit-logs` | Auditlogs bekijken |
+| POST | `/import/tickets` | Tickets importeren |
+| GET/POST | `/kb/categories` | KB-categorieën beheren |
+| GET/POST | `/kb/articles` | KB-artikelen beheren |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| Methode | Pad | Beschrijving |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | Toegewezen/gefilterde tickets weergeven |
+| GET | `/tickets/{id}` | Ticket bekijken |
+| POST | `/tickets/{id}/replies` | Antwoord toevoegen |
+| POST | `/tickets/{id}/macro/{macroId}` | Macro toepassen |
+| POST | `/tickets/{id}/side-conversations` | Zijgesprek aanmaken |
+| POST | `/tickets/{id}/links` | Tickets koppelen |
+| GET/POST | `/saved-views` | Opgeslagen weergaven beheren |
+| GET/POST | `/canned-responses` | Standaardantwoorden beheren |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| Methode | Pad | Beschrijving |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | Klanttickets weergeven |
+| POST | `/tickets` | Ticket aanmaken |
+| POST | `/tickets/{id}/replies` | Antwoord toevoegen |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| Methode | Pad | Beschrijving |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | Ticket aanmaken (openbaar) |
+| GET | `/tickets/{token}` | Ticket bekijken via gasttoken |
+| POST | `/tickets/{token}/replies` | Antwoorden via gasttoken |
+| GET | `/kb/search?query=` | Kennisbank doorzoeken |
+| POST | `/csat/{token}` | Tevredenheidsbeoordeling indienen |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| Methode | Pad | Beschrijving |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | Ticket bekijken |
+| GET | `/tickets/{token}/replies` | Antwoorden bekijken |
+| POST | `/tickets/{token}/replies` | Antwoord toevoegen |
 
-## Architecture
+## Architectuur
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              Auto-configuratie, eigenschappen, WebSocket-configuratie
+  models/              JPA-entiteiten met volledige relaties
+  repositories/        Spring Data JPA-repositories
+  services/            Bedrijfslogica (transactioneel)
   controllers/
     admin/             Admin REST API
     agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    customer/          Klant REST API
+    widget/            Openbare widget-API
+  events/              Spring-applicatiegebeurtenissen + webhook-listener
+  security/            API-tokenauthenticatiefilter, beveiligingsconfiguratie, 2FA
+  scheduling/          @Scheduled-taken (snooze, SLA, automatiseringen)
 ```
 
-## Authentication
+## Authenticatie
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+API-endpoints gebruiken Bearer-tokenauthenticatie. Maak tokens aan via de admin-API:
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+Het antwoord bevat het token in platte tekst (wordt slechts eenmaal getoond). Gebruik het in volgende verzoeken:
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (Realtime)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+Activeer met `escalated.broadcasting.enabled=true`. Verbind met `/escalated/ws` via SockJS/STOMP.
 
-## Development
+## Ontwikkeling
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## Licentie
 
-MIT License. See [LICENSE](LICENSE) for details.
+MIT-licentie. Zie [LICENSE](LICENSE) voor details.

--- a/docs/translations/README.pl.md
+++ b/docs/translations/README.pl.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Wbudowywalny system helpdesk dla aplikacji Spring Boot. Dodaj w pełni funkcjonalne biuro wsparcia do dowolnej aplikacji Java za pomocą jednej zależności.
 
 ## Funkcje
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- Pełne zarządzanie cyklem życia ze statusami, priorytetami i przypisaniami
+2. **SLA Policies** -- Konfigurowalne SLA ze wsparciem godzin pracy i kalendarzami świąt
+3. **Automations** -- Reguły czasowe do automatycznego zamykania rozwiązanych zgłoszeń i automatycznego przypisywania
+4. **Escalation Rules** -- Automatyczna eskalacja przy naruszeniu SLA z ponownym przypisaniem i powiadomieniami
+5. **Macros & Canned Responses** -- Predefiniowane akcje i szablony odpowiedzi dla agentów
+6. **Custom Fields** -- Rozszerzalne dane zgłoszeń z wieloma typami pól
+7. **Knowledge Base** -- Artykuły i kategorie z wyszukiwaniem, licznikiem wyświetleń i opiniami
+8. **Webhooks** -- Dostarczanie webhooków podpisanych HMAC z logiką ponawiania
+9. **API Tokens** -- Uwierzytelnianie tokenem hashowanym SHA-256 dla dostępu do API
+10. **Roles & Permissions** -- Szczegółowa kontrola dostępu oparta na rolach
+11. **Audit Logging** -- Pełny ślad audytu dla wszystkich akcji
+12. **Import System** -- Masowy import zgłoszeń ze strukturyzowanych danych
+13. **Side Conversations** -- Prywatne konwersacje wątkowe wewnątrz zgłoszeń
+14. **Ticket Merging & Linking** -- Łączenie duplikatów zgłoszeń i wiązanie powiązanych
+15. **Ticket Splitting** -- Dzielenie złożonych zgłoszeń na oddzielne problemy
+16. **Ticket Snooze** -- Odkładanie zgłoszeń z automatycznym budzeniem przez `@Scheduled`
+17. **Email Threading** -- Markowe szablony e-mail HTML przez Thymeleaf z prawidłowym wątkowaniem Message-ID
+18. **Saved Views** -- Niestandardowe filtrowane/sortowane widoki zgłoszeń na agenta
+19. **Widget API** -- Publiczne endpointy REST do osadzania widgetu wsparcia
+20. **Real-time Broadcasting** -- WebSocket przez STOMP/SockJS (opcjonalnie)
+21. **Capacity Management** -- Śledzenie i egzekwowanie limitów obciążenia agentów
+22. **Skill-based Routing** -- Kierowanie zgłoszeń do agentów z odpowiednimi umiejętnościami
+23. **CSAT Ratings** -- Ankiety satysfakcji klienta z dostępem opartym na tokenie
+24. **2FA (TOTP)** -- Obsługa haseł jednorazowych opartych na czasie dla kont agentów
+25. **Guest Access** -- Dostęp do zgłoszeń oparty na tokenie bez uwierzytelniania
 
 ## Wymagania
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- Relacyjna baza danych (PostgreSQL, MySQL lub H2 do programowania)
 
 ## Instalacja
 
-Add the dependency to your `build.gradle.kts`:
+Dodaj zależność do pliku `build.gradle.kts`:
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+Lub `pom.xml`:
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## Konfiguracja
 
-Add to your `application.properties` or `application.yml`:
+Dodaj do pliku `application.properties` lub `application.yml`:
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## Konfiguracja bazy danych
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Migracje Flyway są dołączone i uruchamiają się automatycznie. Migracja tworzy wszystkie tabele z prefiksem `escalated_` i inicjalizuje domyślne role i uprawnienia.
 
-## API Endpoints
+## Endpointy API
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| Metoda | Ścieżka | Opis |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | Lista zgłoszeń (paginowana, z filtrami) |
+| POST | `/tickets` | Utwórz zgłoszenie |
+| GET | `/tickets/{id}` | Pobierz zgłoszenie |
+| PUT | `/tickets/{id}` | Aktualizuj zgłoszenie |
+| POST | `/tickets/{id}/assign` | Przypisz zgłoszenie |
+| POST | `/tickets/{id}/status` | Zmień status |
+| POST | `/tickets/{id}/snooze` | Odłóż zgłoszenie |
+| POST | `/tickets/{id}/merge` | Scal zgłoszenia |
+| POST | `/tickets/{id}/split` | Podziel zgłoszenie |
+| DELETE | `/tickets/{id}` | Usuń zgłoszenie |
+| GET/POST | `/departments` | Zarządzaj działami |
+| GET/POST | `/agents` | Zarządzaj agentami |
+| GET/POST | `/webhooks` | Zarządzaj webhookami |
+| GET/POST | `/roles` | Zarządzaj rolami |
+| GET/POST | `/custom-fields` | Zarządzaj polami niestandardowymi |
+| GET/POST | `/settings` | Zarządzaj ustawieniami |
+| GET | `/audit-logs` | Wyświetl dzienniki audytu |
+| POST | `/import/tickets` | Importuj zgłoszenia |
+| GET/POST | `/kb/categories` | Zarządzaj kategoriami KB |
+| GET/POST | `/kb/articles` | Zarządzaj artykułami KB |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| Metoda | Ścieżka | Opis |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | Lista przypisanych/przefiltrowanych zgłoszeń |
+| GET | `/tickets/{id}` | Wyświetl zgłoszenie |
+| POST | `/tickets/{id}/replies` | Dodaj odpowiedź |
+| POST | `/tickets/{id}/macro/{macroId}` | Zastosuj makro |
+| POST | `/tickets/{id}/side-conversations` | Utwórz konwersację poboczną |
+| POST | `/tickets/{id}/links` | Powiąż zgłoszenia |
+| GET/POST | `/saved-views` | Zarządzaj zapisanymi widokami |
+| GET/POST | `/canned-responses` | Zarządzaj szablonami odpowiedzi |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| Metoda | Ścieżka | Opis |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | Lista zgłoszeń klienta |
+| POST | `/tickets` | Utwórz zgłoszenie |
+| POST | `/tickets/{id}/replies` | Dodaj odpowiedź |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| Metoda | Ścieżka | Opis |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | Utwórz zgłoszenie (publiczne) |
+| GET | `/tickets/{token}` | Wyświetl zgłoszenie tokenem gościa |
+| POST | `/tickets/{token}/replies` | Odpowiedz tokenem gościa |
+| GET | `/kb/search?query=` | Przeszukaj bazę wiedzy |
+| POST | `/csat/{token}` | Prześlij ocenę satysfakcji |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| Metoda | Ścieżka | Opis |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | Wyświetl zgłoszenie |
+| GET | `/tickets/{token}/replies` | Wyświetl odpowiedzi |
+| POST | `/tickets/{token}/replies` | Dodaj odpowiedź |
 
-## Architecture
+## Architektura
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              Auto-konfiguracja, właściwości, konfiguracja WebSocket
+  models/              Encje JPA z pełnymi relacjami
+  repositories/        Repozytoria Spring Data JPA
+  services/            Logika biznesowa (transakcyjna)
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             Administracyjne REST API
+    agent/             REST API agenta
+    customer/          REST API klienta
+    widget/            Publiczne API widgetu
+  events/              Zdarzenia aplikacji Spring + listener webhooków
+  security/            Filtr uwierzytelniania tokenem API, konfiguracja bezpieczeństwa, 2FA
+  scheduling/          Zadania @Scheduled (odkładanie, SLA, automatyzacje)
 ```
 
-## Authentication
+## Uwierzytelnianie
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+Endpointy API używają uwierzytelniania tokenem Bearer. Utwórz tokeny przez API administracyjne:
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+Odpowiedź zawiera token w postaci jawnej (wyświetlany tylko raz). Użyj go w kolejnych żądaniach:
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (Czas rzeczywisty)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+Aktywuj za pomocą `escalated.broadcasting.enabled=true`. Połącz się z `/escalated/ws` przez SockJS/STOMP.
 
-## Development
+## Programowanie
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## Licencja
 
-MIT License. See [LICENSE](LICENSE) for details.
+Licencja MIT. Zobacz [LICENSE](LICENSE), aby uzyskać szczegóły.

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Um sistema de helpdesk incorporável para aplicações Spring Boot. Adicione um suporte completo a qualquer aplicação Java com uma única dependência.
 
-## Recursos
+## Funcionalidades
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- Gerenciamento completo do ciclo de vida com status, prioridades e atribuições
+2. **SLA Policies** -- SLAs configuráveis com suporte a horário comercial e calendários de feriados
+3. **Automations** -- Regras baseadas em tempo para fechamento automático de tickets resolvidos e atribuição automática
+4. **Escalation Rules** -- Escalonamento automático por violação de SLA com reatribuição e notificações
+5. **Macros & Canned Responses** -- Ações predefinidas e modelos de resposta para agentes
+6. **Custom Fields** -- Dados de tickets extensíveis com múltiplos tipos de campos
+7. **Knowledge Base** -- Artigos e categorias com busca, contagem de visualizações e feedback
+8. **Webhooks** -- Entrega de webhooks assinados com HMAC com lógica de repetição
+9. **API Tokens** -- Autenticação por token hasheado com SHA-256 para acesso à API
+10. **Roles & Permissions** -- Controle de acesso granular baseado em funções
+11. **Audit Logging** -- Trilha de auditoria completa para todas as ações
+12. **Import System** -- Importação em massa de tickets a partir de dados estruturados
+13. **Side Conversations** -- Conversas privadas com threads dentro dos tickets
+14. **Ticket Merging & Linking** -- Mesclar tickets duplicados e vincular relacionados
+15. **Ticket Splitting** -- Dividir tickets complexos em problemas separados
+16. **Ticket Snooze** -- Adiar tickets com despertar automático via `@Scheduled`
+17. **Email Threading** -- Modelos de e-mail HTML personalizados via Thymeleaf com encadeamento correto de Message-ID
+18. **Saved Views** -- Visualizações de tickets personalizadas filtradas/ordenadas por agente
+19. **Widget API** -- Endpoints REST públicos para incorporar um widget de suporte
+20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opcional)
+21. **Capacity Management** -- Rastreamento e aplicação de limites de carga de trabalho de agentes
+22. **Skill-based Routing** -- Roteamento de tickets para agentes com habilidades correspondentes
+23. **CSAT Ratings** -- Pesquisas de satisfação do cliente com acesso baseado em token
+24. **2FA (TOTP)** -- Suporte a senha de uso único baseada em tempo para contas de agentes
+25. **Guest Access** -- Acesso a tickets baseado em token sem autenticação
 
 ## Requisitos
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- Um banco de dados relacional (PostgreSQL, MySQL ou H2 para desenvolvimento)
 
 ## Instalação
 
-Add the dependency to your `build.gradle.kts`:
+Adicione a dependência ao seu `build.gradle.kts`:
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+Ou `pom.xml`:
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## Configuração
 
-Add to your `application.properties` or `application.yml`:
+Adicione ao seu `application.properties` ou `application.yml`:
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## Configuração do banco de dados
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+As migrações Flyway estão incluídas e são executadas automaticamente. A migração cria todas as tabelas com o prefixo `escalated_` e inicializa funções e permissões padrão.
 
-## API Endpoints
+## Endpoints da API
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| Método | Caminho | Descrição |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | Listar tickets (paginado, filtrável) |
+| POST | `/tickets` | Criar ticket |
+| GET | `/tickets/{id}` | Obter ticket |
+| PUT | `/tickets/{id}` | Atualizar ticket |
+| POST | `/tickets/{id}/assign` | Atribuir ticket |
+| POST | `/tickets/{id}/status` | Alterar status |
+| POST | `/tickets/{id}/snooze` | Adiar ticket |
+| POST | `/tickets/{id}/merge` | Mesclar tickets |
+| POST | `/tickets/{id}/split` | Dividir ticket |
+| DELETE | `/tickets/{id}` | Excluir ticket |
+| GET/POST | `/departments` | Gerenciar departamentos |
+| GET/POST | `/agents` | Gerenciar agentes |
+| GET/POST | `/webhooks` | Gerenciar webhooks |
+| GET/POST | `/roles` | Gerenciar funções |
+| GET/POST | `/custom-fields` | Gerenciar campos personalizados |
+| GET/POST | `/settings` | Gerenciar configurações |
+| GET | `/audit-logs` | Ver logs de auditoria |
+| POST | `/import/tickets` | Importar tickets |
+| GET/POST | `/kb/categories` | Gerenciar categorias da KB |
+| GET/POST | `/kb/articles` | Gerenciar artigos da KB |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| Método | Caminho | Descrição |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | Listar tickets atribuídos/filtrados |
+| GET | `/tickets/{id}` | Visualizar ticket |
+| POST | `/tickets/{id}/replies` | Adicionar resposta |
+| POST | `/tickets/{id}/macro/{macroId}` | Aplicar macro |
+| POST | `/tickets/{id}/side-conversations` | Criar conversa lateral |
+| POST | `/tickets/{id}/links` | Vincular tickets |
+| GET/POST | `/saved-views` | Gerenciar visualizações salvas |
+| GET/POST | `/canned-responses` | Gerenciar respostas predefinidas |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| Método | Caminho | Descrição |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | Listar tickets do cliente |
+| POST | `/tickets` | Criar ticket |
+| POST | `/tickets/{id}/replies` | Adicionar resposta |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| Método | Caminho | Descrição |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | Criar ticket (público) |
+| GET | `/tickets/{token}` | Visualizar ticket por token de convidado |
+| POST | `/tickets/{token}/replies` | Responder via token de convidado |
+| GET | `/kb/search?query=` | Pesquisar base de conhecimento |
+| POST | `/csat/{token}` | Enviar avaliação de satisfação |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| Método | Caminho | Descrição |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | Visualizar ticket |
+| GET | `/tickets/{token}/replies` | Visualizar respostas |
+| POST | `/tickets/{token}/replies` | Adicionar resposta |
 
-## Architecture
+## Arquitetura
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              Auto-configuração, propriedades, configuração WebSocket
+  models/              Entidades JPA com relacionamentos completos
+  repositories/        Repositórios Spring Data JPA
+  services/            Lógica de negócios (transacional)
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             API REST do administrador
+    agent/             API REST do agente
+    customer/          API REST do cliente
+    widget/            API pública do widget
+  events/              Eventos de aplicação Spring + listener de webhooks
+  security/            Filtro de autenticação de token API, configuração de segurança, 2FA
+  scheduling/          Tarefas @Scheduled (adiamento, SLA, automações)
 ```
 
-## Authentication
+## Autenticação
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+Os endpoints da API usam autenticação por token Bearer. Crie tokens pela API de administrador:
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+A resposta inclui o token em texto simples (exibido apenas uma vez). Use-o em solicitações subsequentes:
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (Tempo real)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+Ative com `escalated.broadcasting.enabled=true`. Conecte-se a `/escalated/ws` via SockJS/STOMP.
 
-## Development
+## Desenvolvimento
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## Licença
 
-MIT License. See [LICENSE](LICENSE) for details.
+Licença MIT. Veja [LICENSE](LICENSE) para detalhes.

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Встраиваемая система helpdesk для приложений Spring Boot. Добавьте полнофункциональную службу поддержки в любое Java-приложение с помощью одной зависимости.
 
 ## Возможности
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- Полное управление жизненным циклом со статусами, приоритетами и назначениями
+2. **SLA Policies** -- Настраиваемые SLA с поддержкой рабочего времени и календарями праздников
+3. **Automations** -- Временные правила для автоматического закрытия решённых заявок и автоназначения
+4. **Escalation Rules** -- Автоматическая эскалация при нарушении SLA с переназначением и уведомлениями
+5. **Macros & Canned Responses** -- Предопределённые действия и шаблоны ответов для агентов
+6. **Custom Fields** -- Расширяемые данные заявок с несколькими типами полей
+7. **Knowledge Base** -- Статьи и категории с поиском, счётчиком просмотров и обратной связью
+8. **Webhooks** -- HMAC-подписанная доставка webhook с логикой повторных попыток
+9. **API Tokens** -- SHA-256 хэшированная аутентификация токенов для доступа к API
+10. **Roles & Permissions** -- Детальное управление доступом на основе ролей
+11. **Audit Logging** -- Полный журнал аудита для всех действий
+12. **Import System** -- Массовый импорт заявок из структурированных данных
+13. **Side Conversations** -- Приватные цепочки разговоров внутри заявок
+14. **Ticket Merging & Linking** -- Объединение дублирующих заявок и связывание родственных
+15. **Ticket Splitting** -- Разделение сложных заявок на отдельные проблемы
+16. **Ticket Snooze** -- Откладывание заявок с автоматическим пробуждением через `@Scheduled`
+17. **Email Threading** -- Брендированные HTML-шаблоны электронной почты через Thymeleaf с правильной цепочкой Message-ID
+18. **Saved Views** -- Пользовательские фильтрованные/сортированные представления заявок для каждого агента
+19. **Widget API** -- Публичные REST-эндпоинты для встраивания виджета поддержки
+20. **Real-time Broadcasting** -- WebSocket через STOMP/SockJS (опционально)
+21. **Capacity Management** -- Отслеживание и применение ограничений рабочей нагрузки агентов
+22. **Skill-based Routing** -- Маршрутизация заявок к агентам с подходящими навыками
+23. **CSAT Ratings** -- Опросы удовлетворённости клиентов с доступом по токену
+24. **2FA (TOTP)** -- Поддержка одноразовых паролей на основе времени для учётных записей агентов
+25. **Guest Access** -- Доступ к заявкам по токену без аутентификации
 
 ## Требования
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- Реляционная база данных (PostgreSQL, MySQL или H2 для разработки)
 
 ## Установка
 
-Add the dependency to your `build.gradle.kts`:
+Добавьте зависимость в файл `build.gradle.kts`:
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+Или `pom.xml`:
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## Конфигурация
 
-Add to your `application.properties` or `application.yml`:
+Добавьте в файл `application.properties` или `application.yml`:
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## Настройка базы данных
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Миграции Flyway включены и выполняются автоматически. Миграция создаёт все таблицы с префиксом `escalated_` и заполняет роли и разрешения по умолчанию.
 
-## API Endpoints
+## Эндпоинты API
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| Метод | Путь | Описание |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | Список заявок (с пагинацией, фильтрами) |
+| POST | `/tickets` | Создать заявку |
+| GET | `/tickets/{id}` | Получить заявку |
+| PUT | `/tickets/{id}` | Обновить заявку |
+| POST | `/tickets/{id}/assign` | Назначить заявку |
+| POST | `/tickets/{id}/status` | Изменить статус |
+| POST | `/tickets/{id}/snooze` | Отложить заявку |
+| POST | `/tickets/{id}/merge` | Объединить заявки |
+| POST | `/tickets/{id}/split` | Разделить заявку |
+| DELETE | `/tickets/{id}` | Удалить заявку |
+| GET/POST | `/departments` | Управление отделами |
+| GET/POST | `/agents` | Управление агентами |
+| GET/POST | `/webhooks` | Управление вебхуками |
+| GET/POST | `/roles` | Управление ролями |
+| GET/POST | `/custom-fields` | Управление пользовательскими полями |
+| GET/POST | `/settings` | Управление настройками |
+| GET | `/audit-logs` | Просмотр журналов аудита |
+| POST | `/import/tickets` | Импорт заявок |
+| GET/POST | `/kb/categories` | Управление категориями базы знаний |
+| GET/POST | `/kb/articles` | Управление статьями базы знаний |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| Метод | Путь | Описание |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | Список назначенных/отфильтрованных заявок |
+| GET | `/tickets/{id}` | Просмотр заявки |
+| POST | `/tickets/{id}/replies` | Добавить ответ |
+| POST | `/tickets/{id}/macro/{macroId}` | Применить макрос |
+| POST | `/tickets/{id}/side-conversations` | Создать побочную беседу |
+| POST | `/tickets/{id}/links` | Связать заявки |
+| GET/POST | `/saved-views` | Управление сохранёнными представлениями |
+| GET/POST | `/canned-responses` | Управление шаблонами ответов |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| Метод | Путь | Описание |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | Список заявок клиента |
+| POST | `/tickets` | Создать заявку |
+| POST | `/tickets/{id}/replies` | Добавить ответ |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| Метод | Путь | Описание |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | Создать заявку (публичную) |
+| GET | `/tickets/{token}` | Просмотр заявки по гостевому токену |
+| POST | `/tickets/{token}/replies` | Ответ через гостевой токен |
+| GET | `/kb/search?query=` | Поиск по базе знаний |
+| POST | `/csat/{token}` | Отправить оценку удовлетворённости |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| Метод | Путь | Описание |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | Просмотр заявки |
+| GET | `/tickets/{token}/replies` | Просмотр ответов |
+| POST | `/tickets/{token}/replies` | Добавить ответ |
 
-## Architecture
+## Архитектура
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              Автоконфигурация, свойства, конфигурация WebSocket
+  models/              JPA-сущности с полными связями
+  repositories/        Репозитории Spring Data JPA
+  services/            Бизнес-логика (транзакционная)
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             REST API администратора
+    agent/             REST API агента
+    customer/          REST API клиента
+    widget/            Публичное API виджета
+  events/              События приложения Spring + слушатель вебхуков
+  security/            Фильтр аутентификации API-токенов, конфигурация безопасности, 2FA
+  scheduling/          Задачи @Scheduled (откладывание, SLA, автоматизации)
 ```
 
-## Authentication
+## Аутентификация
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+Эндпоинты API используют аутентификацию Bearer-токенами. Создавайте токены через API администратора:
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+Ответ содержит токен в открытом виде (показывается только один раз). Используйте его в последующих запросах:
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (Реальное время)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+Активируйте с помощью `escalated.broadcasting.enabled=true`. Подключитесь к `/escalated/ws` через SockJS/STOMP.
 
-## Development
+## Разработка
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## Лицензия
 
-MIT License. See [LICENSE](LICENSE) for details.
+Лицензия MIT. Подробности см. в [LICENSE](LICENSE).

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+Spring Boot uygulamaları için gömülebilir yardım masası sistemi. Tek bir bağımlılıkla herhangi bir Java uygulamasına tam özellikli bir destek masası ekleyin.
 
 ## Özellikler
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- Durumlar, öncelikler ve atamalarla tam yaşam döngüsü yönetimi
+2. **SLA Policies** -- Çalışma saatleri desteği ve tatil takvimleri ile yapılandırılabilir SLA'lar
+3. **Automations** -- Çözülmüş taleplerin otomatik kapatılması ve otomatik atama için zaman tabanlı kurallar
+4. **Escalation Rules** -- SLA ihlalinde yeniden atama ve bildirimlerle otomatik yükseltme
+5. **Macros & Canned Responses** -- Temsilciler için önceden tanımlanmış eylemler ve yanıt şablonları
+6. **Custom Fields** -- Birden fazla alan türüyle genişletilebilir talep verileri
+7. **Knowledge Base** -- Arama, görüntüleme sayacı ve geri bildirimli makaleler ve kategoriler
+8. **Webhooks** -- Yeniden deneme mantığıyla HMAC imzalı webhook teslimatı
+9. **API Tokens** -- API erişimi için SHA-256 hashlenmiş token kimlik doğrulaması
+10. **Roles & Permissions** -- Ayrıntılı rol tabanlı erişim kontrolü
+11. **Audit Logging** -- Tüm eylemler için eksiksiz denetim izi
+12. **Import System** -- Yapılandırılmış verilerden toplu talep içe aktarma
+13. **Side Conversations** -- Talepler içinde özel iş parçacıklı konuşmalar
+14. **Ticket Merging & Linking** -- Yinelenen talepleri birleştirme ve ilişkileri bağlama
+15. **Ticket Splitting** -- Karmaşık talepleri ayrı sorunlara bölme
+16. **Ticket Snooze** -- `@Scheduled` ile otomatik uyandırmalı talep erteleme
+17. **Email Threading** -- Thymeleaf ile markalı HTML e-posta şablonları ve doğru Message-ID zincirleme
+18. **Saved Views** -- Temsilci başına özelleştirilmiş filtrelenmiş/sıralanmış talep görünümleri
+19. **Widget API** -- Destek widget'ı gömmek için genel REST uç noktaları
+20. **Real-time Broadcasting** -- STOMP/SockJS üzerinden WebSocket (isteğe bağlı)
+21. **Capacity Management** -- Temsilci iş yükü sınırlarını izleme ve uygulama
+22. **Skill-based Routing** -- Talepleri eşleşen becerilere sahip temsilcilere yönlendirme
+23. **CSAT Ratings** -- Token tabanlı erişimle müşteri memnuniyeti anketleri
+24. **2FA (TOTP)** -- Temsilci hesapları için zamana dayalı tek kullanımlık şifre desteği
+25. **Guest Access** -- Kimlik doğrulaması olmadan token tabanlı talep erişimi
 
 ## Gereksinimler
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- İlişkisel bir veritabanı (PostgreSQL, MySQL veya geliştirme için H2)
 
 ## Kurulum
 
-Add the dependency to your `build.gradle.kts`:
+Bağımlılığı `build.gradle.kts` dosyanıza ekleyin:
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+Veya `pom.xml`:
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## Yapılandırma
 
-Add to your `application.properties` or `application.yml`:
+`application.properties` veya `application.yml` dosyanıza ekleyin:
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## Veritabanı Kurulumu
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Flyway göçleri dahildir ve otomatik olarak çalışır. Göç, `escalated_` önekiyle tüm tabloları oluşturur ve varsayılan rolleri ve izinleri başlatır.
 
-## API Endpoints
+## API Uç Noktaları
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| Yöntem | Yol | Açıklama |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | Talepleri listele (sayfalanmış, filtrelenebilir) |
+| POST | `/tickets` | Talep oluştur |
+| GET | `/tickets/{id}` | Talep getir |
+| PUT | `/tickets/{id}` | Talep güncelle |
+| POST | `/tickets/{id}/assign` | Talep ata |
+| POST | `/tickets/{id}/status` | Durum değiştir |
+| POST | `/tickets/{id}/snooze` | Talebi ertele |
+| POST | `/tickets/{id}/merge` | Talepleri birleştir |
+| POST | `/tickets/{id}/split` | Talebi böl |
+| DELETE | `/tickets/{id}` | Talebi sil |
+| GET/POST | `/departments` | Departmanları yönet |
+| GET/POST | `/agents` | Temsilcileri yönet |
+| GET/POST | `/webhooks` | Webhook'ları yönet |
+| GET/POST | `/roles` | Rolleri yönet |
+| GET/POST | `/custom-fields` | Özel alanları yönet |
+| GET/POST | `/settings` | Ayarları yönet |
+| GET | `/audit-logs` | Denetim günlüklerini görüntüle |
+| POST | `/import/tickets` | Talepleri içe aktar |
+| GET/POST | `/kb/categories` | KB kategorilerini yönet |
+| GET/POST | `/kb/articles` | KB makalelerini yönet |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| Yöntem | Yol | Açıklama |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | Atanmış/filtrelenmiş talepleri listele |
+| GET | `/tickets/{id}` | Talebi görüntüle |
+| POST | `/tickets/{id}/replies` | Yanıt ekle |
+| POST | `/tickets/{id}/macro/{macroId}` | Makro uygula |
+| POST | `/tickets/{id}/side-conversations` | Yan konuşma oluştur |
+| POST | `/tickets/{id}/links` | Talepleri bağla |
+| GET/POST | `/saved-views` | Kaydedilmiş görünümleri yönet |
+| GET/POST | `/canned-responses` | Hazır yanıtları yönet |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| Yöntem | Yol | Açıklama |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | Müşteri taleplerini listele |
+| POST | `/tickets` | Talep oluştur |
+| POST | `/tickets/{id}/replies` | Yanıt ekle |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| Yöntem | Yol | Açıklama |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | Talep oluştur (genel) |
+| GET | `/tickets/{token}` | Misafir tokeniyle talebi görüntüle |
+| POST | `/tickets/{token}/replies` | Misafir tokeniyle yanıtla |
+| GET | `/kb/search?query=` | Bilgi tabanında ara |
+| POST | `/csat/{token}` | Memnuniyet değerlendirmesi gönder |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| Yöntem | Yol | Açıklama |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | Talebi görüntüle |
+| GET | `/tickets/{token}/replies` | Yanıtları görüntüle |
+| POST | `/tickets/{token}/replies` | Yanıt ekle |
 
-## Architecture
+## Mimari
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              Otomatik yapılandırma, özellikler, WebSocket yapılandırması
+  models/              Tam ilişkilere sahip JPA varlıkları
+  repositories/        Spring Data JPA depoları
+  services/            İş mantığı (işlemsel)
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             Yönetici REST API
+    agent/             Temsilci REST API
+    customer/          Müşteri REST API
+    widget/            Genel widget API
+  events/              Spring uygulama olayları + webhook dinleyicisi
+  security/            API token kimlik doğrulama filtresi, güvenlik yapılandırması, 2FA
+  scheduling/          @Scheduled görevleri (erteleme, SLA, otomasyonlar)
 ```
 
-## Authentication
+## Kimlik Doğrulama
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+API uç noktaları Bearer token kimlik doğrulaması kullanır. Yönetici API'si aracılığıyla token oluşturun:
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+Yanıt, düz metin tokeni içerir (yalnızca bir kez gösterilir). Sonraki isteklerde kullanın:
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket (Gerçek zamanlı)
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+`escalated.broadcasting.enabled=true` ile etkinleştirin. SockJS/STOMP aracılığıyla `/escalated/ws`'ye bağlanın.
 
-## Development
+## Geliştirme
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## Lisans
 
-MIT License. See [LICENSE](LICENSE) for details.
+MIT Lisansı. Ayrıntılar için [LICENSE](LICENSE) dosyasına bakın.

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -17,51 +17,51 @@
 
 # Escalated Spring
 
-An embeddable helpdesk system for Spring Boot applications. Add a full-featured support desk to any Java application with a single dependency.
+适用于 Spring Boot 应用程序的可嵌入式帮助台系统。通过单个依赖项为任何 Java 应用程序添加功能齐全的支持台。
 
-## 功能特性
+## 功能
 
-1. **Ticket CRUD** -- Full lifecycle management with statuses, priorities, and assignments
-2. **SLA Policies** -- Configurable SLAs with business hours support and holiday calendars
-3. **Automations** -- Time-based rules for auto-closing resolved tickets and auto-assignment
-4. **Escalation Rules** -- Automatic escalation on SLA breach with reassignment and notifications
-5. **Macros & Canned Responses** -- Pre-defined actions and response templates for agents
-6. **Custom Fields** -- Extensible ticket data with multiple field types
-7. **Knowledge Base** -- Articles and categories with search, view counts, and feedback
-8. **Webhooks** -- HMAC-signed webhook delivery with retry logic
-9. **API Tokens** -- SHA-256 hashed token authentication for API access
-10. **Roles & Permissions** -- Granular role-based access control
-11. **Audit Logging** -- Complete audit trail for all actions
-12. **Import System** -- Bulk ticket import from structured data
-13. **Side Conversations** -- Private threaded conversations within tickets
-14. **Ticket Merging & Linking** -- Merge duplicate tickets and link related ones
-15. **Ticket Splitting** -- Split complex tickets into separate issues
-16. **Ticket Snooze** -- Snooze tickets with automatic wake-up via `@Scheduled`
-17. **Email Threading** -- Branded HTML email templates via Thymeleaf with proper Message-ID threading
-18. **Saved Views** -- Custom filtered/sorted ticket views per agent
-19. **Widget API** -- Public REST endpoints for embedding a support widget
-20. **Real-time Broadcasting** -- WebSocket via STOMP/SockJS (opt-in)
-21. **Capacity Management** -- Track and enforce agent workload limits
-22. **Skill-based Routing** -- Route tickets to agents with matching skills
-23. **CSAT Ratings** -- Customer satisfaction surveys with token-based access
-24. **2FA (TOTP)** -- Time-based one-time password support for agent accounts
-25. **Guest Access** -- Token-based ticket access without authentication
+1. **Ticket CRUD** -- 通过状态、优先级和分配实现完整的生命周期管理
+2. **SLA Policies** -- 可配置的 SLA，支持工作时间和假日日历
+3. **Automations** -- 基于时间的规则，用于自动关闭已解决的工单和自动分配
+4. **Escalation Rules** -- SLA 违规时自动升级，包含重新分配和通知
+5. **Macros & Canned Responses** -- 为客服人员提供预定义操作和响应模板
+6. **Custom Fields** -- 支持多种字段类型的可扩展工单数据
+7. **Knowledge Base** -- 包含搜索、浏览计数和反馈的文章和分类
+8. **Webhooks** -- 带重试逻辑的 HMAC 签名 Webhook 交付
+9. **API Tokens** -- 用于 API 访问的 SHA-256 哈希令牌认证
+10. **Roles & Permissions** -- 细粒度的基于角色的访问控制
+11. **Audit Logging** -- 所有操作的完整审计跟踪
+12. **Import System** -- 从结构化数据批量导入工单
+13. **Side Conversations** -- 工单内的私密线程对话
+14. **Ticket Merging & Linking** -- 合并重复工单并链接相关工单
+15. **Ticket Splitting** -- 将复杂工单拆分为独立问题
+16. **Ticket Snooze** -- 通过 `@Scheduled` 自动唤醒的工单休眠
+17. **Email Threading** -- 通过 Thymeleaf 实现品牌化 HTML 邮件模板和正确的 Message-ID 线程
+18. **Saved Views** -- 每个客服人员的自定义过滤/排序工单视图
+19. **Widget API** -- 用于嵌入支持小部件的公共 REST 端点
+20. **Real-time Broadcasting** -- 通过 STOMP/SockJS 的 WebSocket（可选启用）
+21. **Capacity Management** -- 跟踪和执行客服人员工作负载限制
+22. **Skill-based Routing** -- 将工单路由到具有匹配技能的客服人员
+23. **CSAT Ratings** -- 基于令牌访问的客户满意度调查
+24. **2FA (TOTP)** -- 客服人员账户的基于时间的一次性密码支持
+25. **Guest Access** -- 无需认证的基于令牌的工单访问
 
-## 系统要求
+## 要求
 
 - Java 17+
 - Spring Boot 3.2+
-- A relational database (PostgreSQL, MySQL, or H2 for development)
+- 关系型数据库（PostgreSQL、MySQL 或用于开发的 H2）
 
 ## 安装
 
-Add the dependency to your `build.gradle.kts`:
+将依赖项添加到 `build.gradle.kts`：
 
 ```kotlin
 implementation("dev.escalated:escalated-spring:0.1.0")
 ```
 
-Or `pom.xml`:
+或 `pom.xml`：
 
 ```xml
 <dependency>
@@ -73,7 +73,7 @@ Or `pom.xml`:
 
 ## 配置
 
-Add to your `application.properties` or `application.yml`:
+添加到 `application.properties` 或 `application.yml`：
 
 ```properties
 # Enable/disable the helpdesk
@@ -106,92 +106,92 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
-## Database Setup
+## 数据库设置
 
-Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.
+Flyway 迁移已包含并自动运行。迁移会创建所有带有 `escalated_` 前缀的表，并初始化默认角色和权限。
 
-## API Endpoints
+## API 端点
 
 ### Admin (`/escalated/api/admin/`)
-| Method | Path | Description |
+| 方法 | 路径 | 描述 |
 |--------|------|-------------|
-| GET | `/tickets` | List tickets (paginated, filterable) |
-| POST | `/tickets` | Create ticket |
-| GET | `/tickets/{id}` | Get ticket |
-| PUT | `/tickets/{id}` | Update ticket |
-| POST | `/tickets/{id}/assign` | Assign ticket |
-| POST | `/tickets/{id}/status` | Change status |
-| POST | `/tickets/{id}/snooze` | Snooze ticket |
-| POST | `/tickets/{id}/merge` | Merge tickets |
-| POST | `/tickets/{id}/split` | Split ticket |
-| DELETE | `/tickets/{id}` | Delete ticket |
-| GET/POST | `/departments` | CRUD departments |
-| GET/POST | `/agents` | CRUD agents |
-| GET/POST | `/webhooks` | CRUD webhooks |
-| GET/POST | `/roles` | CRUD roles |
-| GET/POST | `/custom-fields` | CRUD custom fields |
-| GET/POST | `/settings` | Manage settings |
-| GET | `/audit-logs` | View audit logs |
-| POST | `/import/tickets` | Import tickets |
-| GET/POST | `/kb/categories` | Manage KB categories |
-| GET/POST | `/kb/articles` | Manage KB articles |
+| GET | `/tickets` | 列出工单（分页、可过滤） |
+| POST | `/tickets` | 创建工单 |
+| GET | `/tickets/{id}` | 获取工单 |
+| PUT | `/tickets/{id}` | 更新工单 |
+| POST | `/tickets/{id}/assign` | 分配工单 |
+| POST | `/tickets/{id}/status` | 更改状态 |
+| POST | `/tickets/{id}/snooze` | 休眠工单 |
+| POST | `/tickets/{id}/merge` | 合并工单 |
+| POST | `/tickets/{id}/split` | 拆分工单 |
+| DELETE | `/tickets/{id}` | 删除工单 |
+| GET/POST | `/departments` | 管理部门 |
+| GET/POST | `/agents` | 管理客服人员 |
+| GET/POST | `/webhooks` | 管理 Webhooks |
+| GET/POST | `/roles` | 管理角色 |
+| GET/POST | `/custom-fields` | 管理自定义字段 |
+| GET/POST | `/settings` | 管理设置 |
+| GET | `/audit-logs` | 查看审计日志 |
+| POST | `/import/tickets` | 导入工单 |
+| GET/POST | `/kb/categories` | 管理知识库分类 |
+| GET/POST | `/kb/articles` | 管理知识库文章 |
 
 ### Agent (`/escalated/api/agent/`)
-| Method | Path | Description |
+| 方法 | 路径 | 描述 |
 |--------|------|-------------|
-| GET | `/tickets` | List assigned/filtered tickets |
-| GET | `/tickets/{id}` | View ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
-| POST | `/tickets/{id}/macro/{macroId}` | Apply macro |
-| POST | `/tickets/{id}/side-conversations` | Create side conversation |
-| POST | `/tickets/{id}/links` | Link tickets |
-| GET/POST | `/saved-views` | Manage saved views |
-| GET/POST | `/canned-responses` | Manage canned responses |
+| GET | `/tickets` | 列出已分配/已过滤的工单 |
+| GET | `/tickets/{id}` | 查看工单 |
+| POST | `/tickets/{id}/replies` | 添加回复 |
+| POST | `/tickets/{id}/macro/{macroId}` | 应用宏 |
+| POST | `/tickets/{id}/side-conversations` | 创建侧边对话 |
+| POST | `/tickets/{id}/links` | 链接工单 |
+| GET/POST | `/saved-views` | 管理已保存的视图 |
+| GET/POST | `/canned-responses` | 管理预设回复 |
 
 ### Customer (`/escalated/api/customer/`)
-| Method | Path | Description |
+| 方法 | 路径 | 描述 |
 |--------|------|-------------|
-| GET | `/tickets?email=` | List customer tickets |
-| POST | `/tickets` | Create ticket |
-| POST | `/tickets/{id}/replies` | Add reply |
+| GET | `/tickets?email=` | 列出客户工单 |
+| POST | `/tickets` | 创建工单 |
+| POST | `/tickets/{id}/replies` | 添加回复 |
 
 ### Widget (`/escalated/api/widget/`)
-| Method | Path | Description |
+| 方法 | 路径 | 描述 |
 |--------|------|-------------|
-| POST | `/tickets` | Create ticket (public) |
-| GET | `/tickets/{token}` | View ticket by guest token |
-| POST | `/tickets/{token}/replies` | Reply via guest token |
-| GET | `/kb/search?query=` | Search knowledge base |
-| POST | `/csat/{token}` | Submit satisfaction rating |
+| POST | `/tickets` | 创建工单（公开） |
+| GET | `/tickets/{token}` | 通过访客令牌查看工单 |
+| POST | `/tickets/{token}/replies` | 通过访客令牌回复 |
+| GET | `/kb/search?query=` | 搜索知识库 |
+| POST | `/csat/{token}` | 提交满意度评分 |
 
 ### Guest (`/escalated/api/guest/`)
-| Method | Path | Description |
+| 方法 | 路径 | 描述 |
 |--------|------|-------------|
-| GET | `/tickets/{token}` | View ticket |
-| GET | `/tickets/{token}/replies` | View replies |
-| POST | `/tickets/{token}/replies` | Add reply |
+| GET | `/tickets/{token}` | 查看工单 |
+| GET | `/tickets/{token}/replies` | 查看回复 |
+| POST | `/tickets/{token}/replies` | 添加回复 |
 
-## Architecture
+## 架构
 
 ```
 dev.escalated/
-  config/              Auto-configuration, properties, WebSocket config
-  models/              JPA entities with full relationships
-  repositories/        Spring Data JPA repositories
-  services/            Business logic (transactional)
+  config/              自动配置、属性、WebSocket 配置
+  models/              具有完整关系的 JPA 实体
+  repositories/        Spring Data JPA 仓库
+  services/            业务逻辑（事务性）
   controllers/
-    admin/             Admin REST API
-    agent/             Agent REST API
-    customer/          Customer REST API
-    widget/            Public widget API
-  events/              Spring application events + webhook listener
-  security/            API token auth filter, security config, 2FA
-  scheduling/          @Scheduled tasks (snooze, SLA, automations)
+    admin/             管理员 REST API
+    agent/             客服人员 REST API
+    customer/          客户 REST API
+    widget/            公共小部件 API
+  events/              Spring 应用程序事件 + Webhook 监听器
+  security/            API 令牌认证过滤器、安全配置、2FA
+  scheduling/          @Scheduled 任务（休眠、SLA、自动化）
 ```
 
-## Authentication
+## 认证
 
-API endpoints use Bearer token authentication. Create tokens via the admin API:
+API 端点使用 Bearer 令牌认证。通过管理员 API 创建令牌：
 
 ```bash
 curl -X POST /escalated/api/admin/tokens \
@@ -199,17 +199,17 @@ curl -X POST /escalated/api/admin/tokens \
   -d '{"name": "My API Token", "agent_id": 1}'
 ```
 
-The response includes the plain-text token (shown only once). Use it in subsequent requests:
+响应包含明文令牌（仅显示一次）。在后续请求中使用：
 
 ```bash
 curl -H "Authorization: Bearer <token>" /escalated/api/agent/tickets
 ```
 
-## WebSocket (Real-time)
+## WebSocket（实时）
 
-Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` via SockJS/STOMP.
+使用 `escalated.broadcasting.enabled=true` 启用。通过 SockJS/STOMP 连接到 `/escalated/ws`。
 
-## Development
+## 开发
 
 ```bash
 # Build
@@ -224,4 +224,4 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 
 ## 许可证
 
-MIT License. See [LICENSE](LICENSE) for details.
+MIT 许可证。详情请参阅 [LICENSE](LICENSE)。


### PR DESCRIPTION
## Summary
- Fully translate all 13 README translation files (ar, de, es, fr, it, ja, ko, nl, pl, pt-BR, ru, tr, zh-CN)
- Translate feature descriptions, section headers, table descriptions, prose paragraphs, and architecture labels
- Keep code blocks, commands, URLs, badges, and technical terms in English

## Test plan
- [ ] Verify each translation file renders correctly on GitHub
- [ ] Spot-check translations for accuracy