### PR TITLE
fix: include url in attachment serialization

### DIFF
--- a/src/main/java/dev/escalated/controllers/AttachmentController.java
+++ b/src/main/java/dev/escalated/controllers/AttachmentController.java
@@ -1,0 +1,52 @@
+package dev.escalated.controllers;
+
+import dev.escalated.models.Attachment;
+import dev.escalated.repositories.AttachmentRepository;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/escalated/api/attachments")
+public class AttachmentController {
+
+    private final AttachmentRepository attachmentRepository;
+
+    public AttachmentController(AttachmentRepository attachmentRepository) {
+        this.attachmentRepository = attachmentRepository;
+    }
+
+    @GetMapping("/{id}/download")
+    public ResponseEntity<Resource> download(@PathVariable Long id) throws IOException {
+        Attachment attachment = attachmentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Attachment not found"));
+
+        Path filePath = Paths.get(attachment.getFilePath());
+        if (!Files.exists(filePath)) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Resource resource = new UrlResource(filePath.toUri());
+
+        String contentType = attachment.getMimeType();
+        if (contentType == null || contentType.isBlank()) {
+            contentType = "application/octet-stream";
+        }
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + attachment.getFileName() + "\"")
+                .body(resource);
+    }
+}

--- a/src/main/java/dev/escalated/models/Attachment.java
+++ b/src/main/java/dev/escalated/models/Attachment.java
@@ -1,5 +1,7 @@
 package dev.escalated.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,10 +13,12 @@ import jakarta.persistence.Table;
 @Table(name = "escalated_attachments")
 public class Attachment extends BaseEntity {
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ticket_id")
     private Ticket ticket;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reply_id")
     private Reply reply;
@@ -22,6 +26,7 @@ public class Attachment extends BaseEntity {
     @Column(name = "file_name", nullable = false)
     private String fileName;
 
+    @JsonIgnore
     @Column(name = "file_path", nullable = false)
     private String filePath;
 
@@ -77,5 +82,10 @@ public class Attachment extends BaseEntity {
 
     public void setMimeType(String mimeType) {
         this.mimeType = mimeType;
+    }
+
+    @JsonProperty("url")
+    public String getUrl() {
+        return "/escalated/api/attachments/" + getId() + "/download";
     }
 }


### PR DESCRIPTION
## Summary
- Fixes escalated-dev/escalated#26 — attachment `url` was never included in serialized JSON output
- Added `@JsonProperty("url")` getter on Attachment entity that generates `/escalated/api/attachments/{id}/download`
- Added `AttachmentController` with download endpoint that streams files with correct MIME type
- Added `@JsonIgnore` on `ticket`, `reply`, and `filePath` to prevent circular refs and path exposure

## Test plan
- [ ] Verify attachments in ticket detail JSON now include `url` field
- [ ] Verify download endpoint streams files correctly