### PR TITLE
feat(demo): upgrade /demo to picker + click-login + agent profile page

### DIFF
--- a/docker/host-app/build.gradle.kts
+++ b/docker/host-app/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("dev.samstevens.totp:totp-spring-boot-starter:1.7.1")
     implementation("org.flywaydb:flyway-core")

--- a/docker/host-app/src/main/java/dev/escalated/demo/DemoApplication.java
+++ b/docker/host-app/src/main/java/dev/escalated/demo/DemoApplication.java
@@ -2,27 +2,10 @@ package dev.escalated.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication(scanBasePackages = {"dev.escalated"})
 public class DemoApplication {
     public static void main(String[] args) {
         SpringApplication.run(DemoApplication.class, args);
-    }
-}
-
-@RestController
-class DemoController {
-    @GetMapping("/")
-    public String home() {
-        return "Escalated Spring Boot demo host. Set APP_ENV=demo for /demo routes.";
-    }
-
-    @GetMapping("/demo")
-    public String demo() {
-        return "<html><body><h1>Escalated Spring Demo</h1>" +
-            "<p>Host project bootstrapped. The /demo picker, click-to-login, " +
-            "and seed work is the remaining punch list — see PR body.</p></body></html>";
     }
 }

--- a/docker/host-app/src/main/java/dev/escalated/demo/DemoController.java
+++ b/docker/host-app/src/main/java/dev/escalated/demo/DemoController.java
@@ -1,0 +1,121 @@
+package dev.escalated.demo;
+
+import dev.escalated.models.AgentProfile;
+import dev.escalated.models.Department;
+import dev.escalated.repositories.AgentProfileRepository;
+import dev.escalated.repositories.DepartmentRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.view.RedirectView;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Controller
+public class DemoController {
+
+    private final AgentProfileRepository agents;
+    private final DepartmentRepository departments;
+
+    public DemoController(AgentProfileRepository agents, DepartmentRepository departments) {
+        this.agents = agents;
+        this.departments = departments;
+    }
+
+    @PostConstruct
+    void seed() {
+        if (agents.count() > 0) return;
+        Department support = new Department();
+        support.setName("Support");
+        support.setActive(true);
+        departments.save(support);
+        Department billing = new Department();
+        billing.setName("Billing");
+        billing.setActive(true);
+        departments.save(billing);
+
+        for (Object[] row : new Object[][]{
+                {"Alice (Admin)", "alice@demo.test", 1L},
+                {"Bob (Agent)", "bob@demo.test", 2L},
+                {"Carol (Agent)", "carol@demo.test", 3L},
+        }) {
+            AgentProfile a = new AgentProfile();
+            a.setName((String) row[0]);
+            a.setEmail((String) row[1]);
+            a.setUserId((Long) row[2]);
+            a.setActive(true);
+            a.setAvailable(true);
+            agents.save(a);
+        }
+    }
+
+    @GetMapping("/")
+    public RedirectView root() {
+        return new RedirectView("/demo");
+    }
+
+    @GetMapping("/demo")
+    @ResponseBody
+    public String picker() {
+        List<AgentProfile> all = agents.findAll();
+        String rows = all.stream().map(a -> String.format(
+                "<form method='POST' action='/demo/login/%d'>" +
+                "<button type='submit' class='user'>" +
+                "<span>%s</span><span class='meta'>%s · UserId %s</span>" +
+                "</button></form>",
+                a.getId(), escape(a.getName()), escape(a.getEmail()), a.getUserId())).collect(Collectors.joining());
+        return picker(rows);
+    }
+
+    @PostMapping("/demo/login/{id}")
+    public RedirectView login(@PathVariable Long id) {
+        return new RedirectView("/demo/agent/" + id);
+    }
+
+    @GetMapping("/demo/agent/{id}")
+    @ResponseBody
+    public String agentPage(@PathVariable Long id) {
+        return agents.findById(id).map(a -> String.format(
+                "<!DOCTYPE html><html><head><meta charset='utf-8'><title>Agent %s</title>" +
+                "<style>%s</style></head><body><div class='wrap'>" +
+                "<h1>Logged in as %s</h1>" +
+                "<p class='meta'>Email: %s · UserId: %s · Active: %s · Available: %s</p>" +
+                "<p>Spring Boot host + Postgres + JPA round-trip verified end-to-end. " +
+                "Department count: %d. Click <a href='/demo'>back to picker</a>.</p>" +
+                "</div></body></html>",
+                escape(a.getName()), styles(),
+                escape(a.getName()), escape(a.getEmail()), a.getUserId(), a.isActive(), a.isAvailable(),
+                departments.count())).orElse("Agent not found");
+    }
+
+    private static String picker(String rows) {
+        return "<!DOCTYPE html><html><head><meta charset='utf-8'><title>Escalated · Spring Demo</title>" +
+                "<style>" + styles() + "</style></head><body><div class='wrap'>" +
+                "<h1>Escalated Spring Demo</h1>" +
+                "<p class='lede'>Click an agent to load their profile. Database seeds on first boot.</p>" +
+                rows +
+                "</div></body></html>";
+    }
+
+    private static String styles() {
+        return "body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0f172a;color:#e2e8f0;margin:0;padding:2rem}" +
+                ".wrap{max-width:720px;margin:0 auto}" +
+                "h1{font-size:1.5rem;margin:0 0 .25rem}" +
+                "p.lede{color:#94a3b8;margin:0 0 2rem}" +
+                "p.meta{color:#94a3b8;font-size:.85rem;margin-bottom:1rem}" +
+                "form{display:block;margin:0}" +
+                "button.user{display:flex;width:100%;align-items:center;justify-content:space-between;padding:.75rem 1rem;background:#1e293b;border:1px solid #334155;border-radius:8px;color:#f1f5f9;font-size:.95rem;cursor:pointer;margin-bottom:.5rem;text-align:left}" +
+                "button.user:hover{background:#273549;border-color:#475569}" +
+                ".meta{color:#94a3b8;font-size:.8rem}" +
+                "a{color:#60a5fa}";
+    }
+
+    private static String escape(String s) {
+        if (s == null) return "";
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    }
+}

--- a/docker/host-app/src/main/java/dev/escalated/demo/DemoSecurityConfig.java
+++ b/docker/host-app/src/main/java/dev/escalated/demo/DemoSecurityConfig.java
@@ -1,0 +1,21 @@
+package dev.escalated.demo;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class DemoSecurityConfig {
+
+    @Bean
+    @Order(0)
+    public SecurityFilterChain demoSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/", "/demo/**")
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}


### PR DESCRIPTION
## Summary

Upgrades the placeholder `/demo` page (merged in #14) to a full end-to-end flow that exercises the whole package stack: Spring Boot host → Hibernate → Postgres → JPA repositories.

- `DemoController` seeds 2 departments + 3 AgentProfiles on first boot
- `/demo` renders an HTML picker, one form per seeded agent
- `POST /demo/login/{id}` 302-redirects to `/demo/agent/{id}`
- `/demo/agent/{id}` reads `AgentProfile` via `JpaRepository` and renders it — round-trips DB + ORM + repo wiring end-to-end
- `DemoSecurityConfig` adds an Order(0) filter chain that permits `/demo/**` (otherwise the package's Order(2) chain catches it under `/escalated/**` auth — wait, it actually only catches `/escalated/**`, but Spring Security's default-deny still kicks in for unmatched paths when `@EnableWebSecurity` is on)
- Host build adds `spring-boot-starter-security` (required since the package's `EscalatedSecurityConfig` pulls in `spring.security.web` types)

## Verification (curl)
```
GET  /demo               -> 200
POST /demo/login/1       -> 302 (Location: /demo/agent/1)
GET  /demo/agent/1       -> 200 (renders Alice (Admin) profile + dept count)
```

## Scope note
This deliberately does NOT plumb an ApiToken through to hit `/escalated/api/agent/tickets`. That endpoint is gated by the package's `ApiTokenAuthenticationFilter`, and seeding/threading a valid token to the click-login flow is enough complexity to belong in its own follow-up PR. The current upgrade proves the host + JPA + package entities all work; full API exercise is deferred.