### PR TITLE
fix(chat): make SimpMessagingTemplate optional in ChatSessionService

### DIFF
--- a/src/main/java/dev/escalated/services/ChatSessionService.java
+++ b/src/main/java/dev/escalated/services/ChatSessionService.java
@@ -9,6 +9,7 @@ import dev.escalated.repositories.ChatSessionRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Manages live-chat session lifecycle: creation, acceptance by an agent,
  * sending messages (stored as ticket replies), and ending sessions.
+ *
+ * <p>The {@link SimpMessagingTemplate} dependency is optional because
+ * STOMP/WebSocket support is gated behind {@code escalated.broadcasting.enabled}.
+ * When broadcasting is disabled, persistence still works correctly; only the
+ * out-of-band fan-out to subscribed STOMP topics is skipped.
  */
 @Service
 public class ChatSessionService {
@@ -23,16 +29,20 @@ public class ChatSessionService {
     private final ChatSessionRepository chatSessionRepository;
     private final TicketService ticketService;
     private final ChatRoutingService chatRoutingService;
-    private final SimpMessagingTemplate messagingTemplate;
+    private final Optional<SimpMessagingTemplate> messagingTemplate;
 
     public ChatSessionService(ChatSessionRepository chatSessionRepository,
                               TicketService ticketService,
                               ChatRoutingService chatRoutingService,
-                              SimpMessagingTemplate messagingTemplate) {
+                              Optional<SimpMessagingTemplate> messagingTemplate) {
         this.chatSessionRepository = chatSessionRepository;
         this.ticketService = ticketService;
         this.chatRoutingService = chatRoutingService;
         this.messagingTemplate = messagingTemplate;
+    }
+
+    private void broadcast(String destination, Object payload) {
+        messagingTemplate.ifPresent(template -> template.convertAndSend(destination, payload));
     }
 
     /**
@@ -71,7 +81,7 @@ public class ChatSessionService {
 
         session = chatSessionRepository.save(session);
 
-        messagingTemplate.convertAndSend("/topic/chat-queue", session);
+        broadcast("/topic/chat-queue", session);
 
         return session;
     }
@@ -96,7 +106,7 @@ public class ChatSessionService {
 
         session = chatSessionRepository.save(session);
 
-        messagingTemplate.convertAndSend("/topic/chat/" + sessionId, session);
+        broadcast("/topic/chat/" + sessionId, session);
 
         return session;
     }
@@ -119,7 +129,7 @@ public class ChatSessionService {
         session.setLastActivityAt(Instant.now());
         chatSessionRepository.save(session);
 
-        messagingTemplate.convertAndSend("/topic/chat/" + sessionId + "/messages", reply);
+        broadcast("/topic/chat/" + sessionId + "/messages", reply);
 
         return reply;
     }
@@ -142,7 +152,7 @@ public class ChatSessionService {
 
         session = chatSessionRepository.save(session);
 
-        messagingTemplate.convertAndSend("/topic/chat/" + sessionId, session);
+        broadcast("/topic/chat/" + sessionId, session);
 
         return session;
     }

--- a/src/test/java/dev/escalated/services/ChatSessionServiceTest.java
+++ b/src/test/java/dev/escalated/services/ChatSessionServiceTest.java
@@ -46,7 +46,7 @@ class ChatSessionServiceTest {
     void setUp() {
         chatRoutingService = new ChatRoutingService(routingRuleRepository);
         chatSessionService = new ChatSessionService(
-                chatSessionRepository, ticketService, chatRoutingService, messagingTemplate);
+                chatSessionRepository, ticketService, chatRoutingService, Optional.of(messagingTemplate));
     }
 
     private Ticket createMockTicket() {
@@ -166,5 +166,29 @@ class ChatSessionServiceTest {
         when(chatSessionRepository.findById(99L)).thenReturn(Optional.empty());
 
         assertThrows(EntityNotFoundException.class, () -> chatSessionService.findById(99L));
+    }
+
+    @Test
+    void start_succeedsWhenMessagingTemplateIsAbsent() {
+        // Service constructed without a SimpMessagingTemplate (broadcasting disabled).
+        ChatSessionService noBroadcast = new ChatSessionService(
+                chatSessionRepository, ticketService, chatRoutingService, Optional.empty());
+
+        Ticket ticket = createMockTicket();
+        when(ticketService.create(anyString(), anyString(), anyString(), anyString(),
+                any(TicketPriority.class), any())).thenReturn(ticket);
+        when(routingRuleRepository.findByActiveTrueOrderByPriorityAsc()).thenReturn(List.of());
+        when(chatSessionRepository.save(any(ChatSession.class))).thenAnswer(invocation -> {
+            ChatSession s = invocation.getArgument(0);
+            s.setId(1L);
+            return s;
+        });
+
+        // Should not throw despite the absent messaging template.
+        ChatSession session = noBroadcast.start("Visitor", "v@test.com", "Hi", null);
+
+        assertNotNull(session);
+        assertEquals("waiting", session.getStatus());
+        verify(chatSessionRepository).save(any(ChatSession.class));
     }
 }


### PR DESCRIPTION
## Summary

`ChatSessionService` declared `SimpMessagingTemplate` as a required constructor argument. `WebSocketConfig` only exposes that bean when `escalated.broadcasting.enabled = true`, so the application failed to boot whenever broadcasting was off — the same failure that forced the docker demo (#14) to ship the env var sidestep.

The fix is the proper one called out in #17: inject `Optional<SimpMessagingTemplate>`, so Spring hands the service an empty `Optional` when the bean isn't published. All four `convertAndSend` call sites are routed through a private `broadcast()` helper that no-ops when the template is absent. Chat persistence (`ticketService.create`, repository saves, status transitions) keeps working; only the out-of-band STOMP fan-out is skipped.

Closes #17

## Test plan

- [x] Existing 8 tests still pass under the `Optional.of(messagingTemplate)` constructor wiring
- [x] New test `start_succeedsWhenMessagingTemplateIsAbsent` constructs the service with `Optional.empty()` and asserts `start(...)` does not throw and still persists the session
- [x] Once merged, the docker demo will no longer need `ESCALATED_BROADCASTING_ENABLED=true` to boot — that env var sidestep can be removed in a follow-up to #14

## Compatibility

This is a constructor signature change (`SimpMessagingTemplate` → `Optional<SimpMessagingTemplate>`). Any consumer wiring the service manually (rather than via Spring's `@Service` autoinjection) needs to wrap their argument. No existing `@Service`-injected consumer in this repo or the demo host needs changes — Spring resolves `Optional<X>` automatically.