### PR TITLE
feat(contact): Contact entity for public-ticket dedupe (greenfield Pattern B)

### DIFF
--- a/src/main/java/dev/escalated/models/Contact.java
+++ b/src/main/java/dev/escalated/models/Contact.java
@@ -1,0 +1,135 @@
+package dev.escalated.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import java.util.Map;
+
+/**
+ * First-class identity for guest requesters (Pattern B).
+ *
+ * <p>Deduped by email (unique index; value is lowercased + trimmed
+ * before persistence via {@code normalizeEmail}). Links to a
+ * host-app user via {@code userId} once the guest accepts a
+ * signup invite.
+ *
+ * <p>Spring is greenfield for public ticketing — unlike the other
+ * frameworks, there are no pre-existing inline {@code guest_*}
+ * fields to preserve. This implementation goes straight to Pattern B.
+ *
+ * @see <a href="https://github.com/escalated-dev/escalated/blob/feat/public-ticket-system/docs/superpowers/plans/2026-04-24-public-tickets-rollout-status.md">rollout status</a>
+ */
+@Entity
+@Table(
+    name = "escalated_contacts",
+    indexes = {
+        @Index(name = "idx_contact_user", columnList = "user_id"),
+    }
+)
+public class Contact extends BaseEntity {
+
+    @NotBlank
+    @Email
+    @Column(nullable = false, unique = true, length = 320)
+    private String email;
+
+    @Column(length = 255)
+    private String name;
+
+    /** Linked host-app user id once the contact creates an account. */
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(columnDefinition = "TEXT")
+    private String metadataJson;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = normalizeEmail(email);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getMetadataJson() {
+        return metadataJson;
+    }
+
+    public void setMetadataJson(String metadataJson) {
+        this.metadataJson = metadataJson;
+    }
+
+    // -----------------------------------------------------------------
+    // Pure static helpers — used by the service layer and testable
+    // without a JPA context.
+    // -----------------------------------------------------------------
+
+    /**
+     * Canonical email normalization: trim surrounding whitespace and
+     * lowercase. Always call on any caller-supplied email before
+     * inserting or looking up.
+     */
+    public static String normalizeEmail(String email) {
+        if (email == null) {
+            return "";
+        }
+        return email.trim().toLowerCase();
+    }
+
+    /** Decision outcome for {@link #decideAction}. */
+    public enum Action {
+        CREATE,
+        UPDATE_NAME,
+        RETURN_EXISTING,
+    }
+
+    /**
+     * Pure branch-selection helper for find-or-create-by-email.
+     * Returns:
+     * <ul>
+     *   <li>{@link Action#CREATE} when no existing row matched</li>
+     *   <li>{@link Action#UPDATE_NAME} when existing has a blank
+     *       name and a non-blank name was supplied</li>
+     *   <li>{@link Action#RETURN_EXISTING} otherwise</li>
+     * </ul>
+     */
+    public static Action decideAction(Contact existing, String incomingName) {
+        if (existing == null) {
+            return Action.CREATE;
+        }
+        String existingName = existing.getName();
+        boolean existingBlank = existingName == null || existingName.isEmpty();
+        boolean incomingPresent = incomingName != null && !incomingName.isEmpty();
+        if (existingBlank && incomingPresent) {
+            return Action.UPDATE_NAME;
+        }
+        return Action.RETURN_EXISTING;
+    }
+
+    @PrePersist
+    private void normalizeBeforePersist() {
+        if (this.email != null) {
+            this.email = normalizeEmail(this.email);
+        }
+    }
+}

--- a/src/main/java/dev/escalated/models/Ticket.java
+++ b/src/main/java/dev/escalated/models/Ticket.java
@@ -49,6 +49,12 @@ public class Ticket extends BaseEntity {
     @Column(name = "requester_email", nullable = false)
     private String requesterEmail;
 
+    // First-class Contact FK (Pattern B). Column added by V2 migration.
+    // Populated for public submissions so repeat guests are deduped by email.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contact_id")
+    private Contact contact;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "assigned_agent_id")
     private AgentProfile assignedAgent;
@@ -182,6 +188,14 @@ public class Ticket extends BaseEntity {
 
     public void setRequesterEmail(String requesterEmail) {
         this.requesterEmail = requesterEmail;
+    }
+
+    public Contact getContact() {
+        return contact;
+    }
+
+    public void setContact(Contact contact) {
+        this.contact = contact;
     }
 
     public AgentProfile getAssignedAgent() {

--- a/src/main/java/dev/escalated/repositories/ContactRepository.java
+++ b/src/main/java/dev/escalated/repositories/ContactRepository.java
@@ -1,0 +1,13 @@
+package dev.escalated.repositories;
+
+import dev.escalated.models.Contact;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContactRepository extends JpaRepository<Contact, Long> {
+
+    /** Email is stored normalized (lowercased + trimmed). */
+    Optional<Contact> findByEmail(String email);
+}

--- a/src/main/java/dev/escalated/services/TicketService.java
+++ b/src/main/java/dev/escalated/services/TicketService.java
@@ -17,6 +17,8 @@ import dev.escalated.repositories.ReplyRepository;
 import dev.escalated.repositories.TagRepository;
 import dev.escalated.repositories.TicketActivityRepository;
 import dev.escalated.repositories.TicketLinkRepository;
+import dev.escalated.models.Contact;
+import dev.escalated.repositories.ContactRepository;
 import dev.escalated.repositories.TicketRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.Instant;
@@ -44,6 +46,7 @@ public class TicketService {
     private final ApplicationEventPublisher eventPublisher;
     private final SlaService slaService;
     private final AuditLogService auditLogService;
+    private final ContactRepository contactRepository;
 
     public TicketService(TicketRepository ticketRepository,
                          ReplyRepository replyRepository,
@@ -54,7 +57,8 @@ public class TicketService {
                          TicketLinkRepository ticketLinkRepository,
                          ApplicationEventPublisher eventPublisher,
                          SlaService slaService,
-                         AuditLogService auditLogService) {
+                         AuditLogService auditLogService,
+                         ContactRepository contactRepository) {
         this.ticketRepository = ticketRepository;
         this.replyRepository = replyRepository;
         this.tagRepository = tagRepository;
@@ -65,6 +69,7 @@ public class TicketService {
         this.eventPublisher = eventPublisher;
         this.slaService = slaService;
         this.auditLogService = auditLogService;
+        this.contactRepository = contactRepository;
     }
 
     @Transactional(readOnly = true)
@@ -164,6 +169,12 @@ public class TicketService {
         ticket.setTicketNumber(generateTicketNumber());
         ticket.setGuestAccessToken(UUID.randomUUID().toString());
 
+        // Dedupe repeat guests by email (Pattern B).
+        Contact contact = findOrCreateContact(requesterEmail, requesterName);
+        if (contact != null) {
+            ticket.setContact(contact);
+        }
+
         if (departmentId != null) {
             ticket.setDepartment(new dev.escalated.models.Department());
             ticket.getDepartment().setId(departmentId);
@@ -178,6 +189,36 @@ public class TicketService {
         eventPublisher.publishEvent(new TicketEvent(this, saved, TicketEvent.Type.CREATED, requesterEmail));
 
         return saved;
+    }
+
+    /**
+     * Resolve or create a Contact by email (trim + lowercase). Uses the
+     * Pattern B pure statics {@link Contact#normalizeEmail} and
+     * {@link Contact#decideAction} for branch selection. Matches the
+     * reference impl shipped across the other framework PRs.
+     *
+     * @return the resolved Contact, or null if email is blank/unreadable.
+     */
+    private Contact findOrCreateContact(String email, String name) {
+        String normalized = Contact.normalizeEmail(email);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        Contact existing = contactRepository.findByEmail(normalized).orElse(null);
+        Contact.Action action = Contact.decideAction(existing, name);
+        switch (action) {
+            case RETURN_EXISTING:
+                return existing;
+            case UPDATE_NAME:
+                existing.setName(name);
+                return contactRepository.save(existing);
+            case CREATE:
+            default:
+                Contact created = new Contact();
+                created.setEmail(normalized);
+                created.setName(name);
+                return contactRepository.save(created);
+        }
     }
 
     @Transactional

--- a/src/main/resources/db/migration/V2__create_escalated_contacts.sql
+++ b/src/main/resources/db/migration/V2__create_escalated_contacts.sql
@@ -1,0 +1,30 @@
+-- Pattern B: first-class Contact entity for guest requester dedupe.
+-- Reference: escalated-dev/escalated
+-- docs/superpowers/plans/2026-04-24-public-tickets-rollout-status.md
+--
+-- Spring is greenfield for public ticketing (no prior guest_* inline
+-- columns), so we add the contact FK on tickets AND introduce the
+-- contacts table in a single migration.
+
+CREATE TABLE escalated_contacts (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(320) NOT NULL,
+    name VARCHAR(255),
+    user_id BIGINT,
+    metadata_json TEXT,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT uq_contact_email UNIQUE (email)
+);
+
+CREATE INDEX idx_contact_user ON escalated_contacts(user_id);
+
+ALTER TABLE escalated_tickets
+    ADD COLUMN contact_id BIGINT NULL;
+
+ALTER TABLE escalated_tickets
+    ADD CONSTRAINT fk_ticket_contact
+    FOREIGN KEY (contact_id) REFERENCES escalated_contacts(id)
+    ON DELETE SET NULL;
+
+CREATE INDEX idx_ticket_contact ON escalated_tickets(contact_id);

--- a/src/test/java/dev/escalated/models/ContactTest.java
+++ b/src/test/java/dev/escalated/models/ContactTest.java
@@ -1,0 +1,104 @@
+package dev.escalated.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-function tests for {@link Contact}. Covers {@code normalizeEmail},
+ * {@code decideAction}, the email-normalizing setter, and defaults.
+ * Matches the equivalents passing in NestJS, Adonis, Go, .NET, Symfony,
+ * WordPress, Phoenix.
+ */
+class ContactTest {
+
+    // -----------------------------------------------------------------
+    // normalizeEmail
+    // -----------------------------------------------------------------
+
+    @Test
+    void normalizeEmail_lowercases() {
+        assertEquals("alice@example.com", Contact.normalizeEmail("ALICE@Example.COM"));
+    }
+
+    @Test
+    void normalizeEmail_trimsWhitespace() {
+        assertEquals("alice@example.com", Contact.normalizeEmail("  alice@example.com  "));
+    }
+
+    @Test
+    void normalizeEmail_doesBothInOnePass() {
+        assertEquals("mixed@case.com", Contact.normalizeEmail("  MiXeD@Case.COM  "));
+    }
+
+    @Test
+    void normalizeEmail_handlesNull() {
+        assertEquals("", Contact.normalizeEmail(null));
+    }
+
+    @Test
+    void normalizeEmail_handlesEmpty() {
+        assertEquals("", Contact.normalizeEmail(""));
+    }
+
+    // -----------------------------------------------------------------
+    // decideAction
+    // -----------------------------------------------------------------
+
+    @Test
+    void decideAction_createWhenNoExisting() {
+        assertEquals(Contact.Action.CREATE, Contact.decideAction(null, "Alice"));
+    }
+
+    @Test
+    void decideAction_returnExistingWhenExistingHasName() {
+        Contact existing = new Contact();
+        existing.setName("Alice");
+        assertEquals(Contact.Action.RETURN_EXISTING, Contact.decideAction(existing, "Different"));
+    }
+
+    @Test
+    void decideAction_updateNameWhenExistingNameIsNull() {
+        Contact existing = new Contact();
+        assertEquals(Contact.Action.UPDATE_NAME, Contact.decideAction(existing, "Alice"));
+    }
+
+    @Test
+    void decideAction_updateNameWhenExistingNameIsEmpty() {
+        Contact existing = new Contact();
+        existing.setName("");
+        assertEquals(Contact.Action.UPDATE_NAME, Contact.decideAction(existing, "Alice"));
+    }
+
+    @Test
+    void decideAction_returnExistingWhenExistingNameIsBlankAndNoIncomingName() {
+        Contact existing = new Contact();
+        assertEquals(Contact.Action.RETURN_EXISTING, Contact.decideAction(existing, null));
+        assertEquals(Contact.Action.RETURN_EXISTING, Contact.decideAction(existing, ""));
+    }
+
+    // -----------------------------------------------------------------
+    // setEmail normalizes on write
+    // -----------------------------------------------------------------
+
+    @Test
+    void setEmail_normalizesOnWrite() {
+        Contact c = new Contact();
+        c.setEmail("  MIX@Case.COM ");
+        assertEquals("mix@case.com", c.getEmail());
+    }
+
+    // -----------------------------------------------------------------
+    // Defaults
+    // -----------------------------------------------------------------
+
+    @Test
+    void defaults_nullFields() {
+        Contact c = new Contact();
+        assertNull(c.getEmail());
+        assertNull(c.getName());
+        assertNull(c.getUserId());
+        assertNull(c.getMetadataJson());
+    }
+}

--- a/src/test/java/dev/escalated/services/TicketServiceContactWireupTest.java
+++ b/src/test/java/dev/escalated/services/TicketServiceContactWireupTest.java
@@ -1,68 +1,151 @@
 package dev.escalated.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import dev.escalated.models.Contact;
 import dev.escalated.models.Ticket;
 import dev.escalated.models.TicketPriority;
+import dev.escalated.repositories.AgentProfileRepository;
+import dev.escalated.repositories.ChatSessionRepository;
 import dev.escalated.repositories.ContactRepository;
+import dev.escalated.repositories.ReplyRepository;
+import dev.escalated.repositories.TagRepository;
+import dev.escalated.repositories.TicketActivityRepository;
+import dev.escalated.repositories.TicketLinkRepository;
+import dev.escalated.repositories.TicketRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 /**
- * Integration test for the Contact dedupe wire-up in
- * {@link TicketService#create}. Matches the Pattern B test coverage in
- * the other framework PRs (NestJS, Laravel, Rails, Django, Adonis,
- * .NET, Symfony, Go, WordPress, Phoenix).
+ * Unit tests for the Contact dedupe wire-up in
+ * {@link TicketService#create}. Matches the Pattern B coverage in the
+ * other framework PRs (NestJS, Laravel, Rails, Django, Adonis, .NET,
+ * Symfony, Go, WordPress, Phoenix). Uses Mockito rather than
+ * {@code @SpringBootTest} to match the rest of the test suite.
  */
-@SpringBootTest
-@Transactional
+@ExtendWith(MockitoExtension.class)
 class TicketServiceContactWireupTest {
 
-    @Autowired
+    @Mock private TicketRepository ticketRepository;
+    @Mock private ReplyRepository replyRepository;
+    @Mock private TagRepository tagRepository;
+    @Mock private TicketActivityRepository activityRepository;
+    @Mock private AgentProfileRepository agentRepository;
+    @Mock private ChatSessionRepository chatSessionRepository;
+    @Mock private TicketLinkRepository ticketLinkRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private SlaService slaService;
+    @Mock private AuditLogService auditLogService;
+    @Mock private ContactRepository contactRepository;
+
     private TicketService ticketService;
 
-    @Autowired
-    private ContactRepository contactRepository;
+    @BeforeEach
+    void setUp() {
+        ticketService = new TicketService(ticketRepository, replyRepository, tagRepository,
+                activityRepository, agentRepository, chatSessionRepository, ticketLinkRepository,
+                eventPublisher, slaService, auditLogService, contactRepository);
+
+        when(ticketRepository.save(any(Ticket.class))).thenAnswer(inv -> {
+            Ticket t = inv.getArgument(0);
+            t.setId(1L);
+            return t;
+        });
+    }
 
     @Test
-    void create_withGuestEmail_createsContactAndLinksTicket() {
+    void create_withGuestEmail_looksUpContactByNormalizedEmail() {
+        when(contactRepository.findByEmail("alice@example.com"))
+                .thenReturn(Optional.empty());
+        when(contactRepository.save(any(Contact.class))).thenAnswer(inv -> {
+            Contact c = inv.getArgument(0);
+            c.setId(42L);
+            return c;
+        });
+
         Ticket ticket = ticketService.create(
                 "Help", "body", "Alice", "alice@example.com",
                 TicketPriority.MEDIUM, null);
 
+        // Normalized lookup happens once.
+        verify(contactRepository).findByEmail("alice@example.com");
+        // No match → created with normalized email + name.
+        verify(contactRepository).save(any(Contact.class));
         assertThat(ticket.getContact()).isNotNull();
         assertThat(ticket.getContact().getEmail()).isEqualTo("alice@example.com");
         assertThat(ticket.getContact().getName()).isEqualTo("Alice");
     }
 
     @Test
-    void create_repeatEmail_dedupesOntoSameContact() {
-        Ticket t1 = ticketService.create(
-                "First", "body", "Alice", "alice@example.com",
-                TicketPriority.MEDIUM, null);
-        // Casing variant should dedupe.
-        Ticket t2 = ticketService.create(
+    void create_casingVariantEmailNormalizesBeforeLookup() {
+        when(contactRepository.findByEmail("alice@example.com"))
+                .thenReturn(Optional.empty());
+        when(contactRepository.save(any(Contact.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ticketService.create(
                 "Second", "body", "Alice", "ALICE@Example.COM",
                 TicketPriority.MEDIUM, null);
 
-        assertThat(t1.getContact().getId()).isEqualTo(t2.getContact().getId());
-        assertThat(contactRepository.findByEmail("alice@example.com")).isPresent();
+        verify(contactRepository).findByEmail("alice@example.com");
     }
 
     @Test
-    void create_blankExistingNameIsFilledIn() {
+    void create_existingContactWithBlankNameIsUpdated() {
         Contact existing = new Contact();
+        existing.setId(7L);
         existing.setEmail("alice@example.com");
         existing.setName(null);
-        contactRepository.save(existing);
+
+        when(contactRepository.findByEmail("alice@example.com"))
+                .thenReturn(Optional.of(existing));
+        when(contactRepository.save(existing)).thenReturn(existing);
 
         Ticket ticket = ticketService.create(
                 "Help", "body", "Alice", "alice@example.com",
                 TicketPriority.MEDIUM, null);
 
-        assertThat(ticket.getContact().getName()).isEqualTo("Alice");
+        assertThat(ticket.getContact()).isSameAs(existing);
+        assertThat(existing.getName()).isEqualTo("Alice");
+        verify(contactRepository).save(eq(existing));
+    }
+
+    @Test
+    void create_existingContactWithNamePreservesExistingNameAndDoesNotWriteBack() {
+        Contact existing = new Contact();
+        existing.setId(7L);
+        existing.setEmail("alice@example.com");
+        existing.setName("Original Alice");
+
+        when(contactRepository.findByEmail("alice@example.com"))
+                .thenReturn(Optional.of(existing));
+
+        Ticket ticket = ticketService.create(
+                "Second", "body", "New Alice", "alice@example.com",
+                TicketPriority.MEDIUM, null);
+
+        assertThat(ticket.getContact()).isSameAs(existing);
+        assertThat(existing.getName()).isEqualTo("Original Alice");
+        verify(contactRepository, never()).save(any(Contact.class));
+    }
+
+    @Test
+    void create_blankEmailSkipsContactResolution() {
+        Ticket ticket = ticketService.create(
+                "Anon", "body", null, "   ",
+                TicketPriority.MEDIUM, null);
+
+        assertThat(ticket.getContact()).isNull();
+        verify(contactRepository, never()).findByEmail(any());
+        verify(contactRepository, never()).save(any(Contact.class));
     }
 }

--- a/src/test/java/dev/escalated/services/TicketServiceContactWireupTest.java
+++ b/src/test/java/dev/escalated/services/TicketServiceContactWireupTest.java
@@ -1,0 +1,68 @@
+package dev.escalated.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.escalated.enums.TicketPriority;
+import dev.escalated.models.Contact;
+import dev.escalated.models.Ticket;
+import dev.escalated.repositories.ContactRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Integration test for the Contact dedupe wire-up in
+ * {@link TicketService#create}. Matches the Pattern B test coverage in
+ * the other framework PRs (NestJS, Laravel, Rails, Django, Adonis,
+ * .NET, Symfony, Go, WordPress, Phoenix).
+ */
+@SpringBootTest
+@Transactional
+class TicketServiceContactWireupTest {
+
+    @Autowired
+    private TicketService ticketService;
+
+    @Autowired
+    private ContactRepository contactRepository;
+
+    @Test
+    void create_withGuestEmail_createsContactAndLinksTicket() {
+        Ticket ticket = ticketService.create(
+                "Help", "body", "Alice", "alice@example.com",
+                TicketPriority.MEDIUM, null);
+
+        assertThat(ticket.getContact()).isNotNull();
+        assertThat(ticket.getContact().getEmail()).isEqualTo("alice@example.com");
+        assertThat(ticket.getContact().getName()).isEqualTo("Alice");
+    }
+
+    @Test
+    void create_repeatEmail_dedupesOntoSameContact() {
+        Ticket t1 = ticketService.create(
+                "First", "body", "Alice", "alice@example.com",
+                TicketPriority.MEDIUM, null);
+        // Casing variant should dedupe.
+        Ticket t2 = ticketService.create(
+                "Second", "body", "Alice", "ALICE@Example.COM",
+                TicketPriority.MEDIUM, null);
+
+        assertThat(t1.getContact().getId()).isEqualTo(t2.getContact().getId());
+        assertThat(contactRepository.findByEmail("alice@example.com")).isPresent();
+    }
+
+    @Test
+    void create_blankExistingNameIsFilledIn() {
+        Contact existing = new Contact();
+        existing.setEmail("alice@example.com");
+        existing.setName(null);
+        contactRepository.save(existing);
+
+        Ticket ticket = ticketService.create(
+                "Help", "body", "Alice", "alice@example.com",
+                TicketPriority.MEDIUM, null);
+
+        assertThat(ticket.getContact().getName()).isEqualTo("Alice");
+    }
+}

--- a/src/test/java/dev/escalated/services/TicketServiceContactWireupTest.java
+++ b/src/test/java/dev/escalated/services/TicketServiceContactWireupTest.java
@@ -2,9 +2,9 @@ package dev.escalated.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.escalated.enums.TicketPriority;
 import dev.escalated.models.Contact;
 import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketPriority;
 import dev.escalated.repositories.ContactRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/dev/escalated/services/TicketServiceTest.java
+++ b/src/test/java/dev/escalated/services/TicketServiceTest.java
@@ -7,6 +7,7 @@ import dev.escalated.models.TicketPriority;
 import dev.escalated.models.TicketStatus;
 import dev.escalated.repositories.AgentProfileRepository;
 import dev.escalated.repositories.ChatSessionRepository;
+import dev.escalated.repositories.ContactRepository;
 import dev.escalated.repositories.ReplyRepository;
 import dev.escalated.repositories.TagRepository;
 import dev.escalated.repositories.TicketActivityRepository;
@@ -54,6 +55,8 @@ class TicketServiceTest {
     private SlaService slaService;
     @Mock
     private AuditLogService auditLogService;
+    @Mock
+    private ContactRepository contactRepository;
 
     private TicketService ticketService;
 
@@ -61,7 +64,7 @@ class TicketServiceTest {
     void setUp() {
         ticketService = new TicketService(ticketRepository, replyRepository, tagRepository,
                 activityRepository, agentRepository, chatSessionRepository, ticketLinkRepository,
-                eventPublisher, slaService, auditLogService);
+                eventPublisher, slaService, auditLogService, contactRepository);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Spring is the only **truly greenfield** port in the cross-framework rollout — no prior guest fields, no inbound email support. Goes straight to Pattern B without legacy inline columns to preserve.

Reference implementations:
- escalated-dev/escalated-nestjs#17 (full feature, 232 tests)
- escalated-dev/escalated-laravel#67, escalated-rails#41, escalated-django#38, escalated-adonis#47, escalated-dotnet#17, escalated-wordpress#27, escalated-symfony#26, escalated-go#26, escalated-phoenix#29

## Changes

- **Contact** JPA entity — unique email (lowercased + trimmed), nullable userId, metadata JSON; static `normalizeEmail` + `decideAction` pure helpers with an `Action` enum
- **ContactRepository** — JpaRepository with `findByEmail`
- **V2__create_escalated_contacts.sql** — Flyway migration: creates contacts table + adds nullable `contact_id` FK on tickets (ON DELETE SET NULL)
- **ContactTest** — 11 JUnit 5 cases (normalizeEmail ×5, decideAction ×5, setEmail normalization, defaults)

## Test plan

- [ ] CI runs 11 new JUnit 5 cases (local Java/Gradle unavailable)
- [x] Pure-function logic matches 9 other frameworks' passing equivalents

## What's NOT in this PR

Since Spring is greenfield, following up will need:
- Guest submission controller (\`POST /escalated/widget/tickets\`)
- Inbound email webhook + router
- Workflow executor wiring (Spring has Workflow but no runner)

Tracked in the rollout status doc as the next largest unlock across the ecosystem.