### PR TITLE
feat(workflow): add WorkflowRunnerService for event-driven workflow firing

### DIFF
--- a/src/main/java/dev/escalated/services/WorkflowRunnerService.java
+++ b/src/main/java/dev/escalated/services/WorkflowRunnerService.java
@@ -1,0 +1,168 @@
+package dev.escalated.services;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.Workflow;
+import dev.escalated.models.WorkflowLog;
+import dev.escalated.repositories.WorkflowLogRepository;
+import dev.escalated.repositories.WorkflowRepository;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Orchestrates evaluation + execution of Workflows for a given trigger
+ * event.
+ *
+ * <p>For each active Workflow matching the trigger (in {@code position}
+ * order), evaluates conditions via {@link WorkflowEngine} and, if matched,
+ * dispatches to {@link WorkflowExecutorService}. Writes a
+ * {@link WorkflowLog} row per Workflow considered. Honors
+ * {@code stop_on_match}.
+ *
+ * <p>Executor errors are caught so one misbehaving workflow never blocks
+ * the rest — the failure is stamped on its log row via {@code errorMessage}.
+ *
+ * <p>Mirrors the NestJS reference {@code workflow-runner.service.ts}.
+ */
+@Service
+public class WorkflowRunnerService {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkflowRunnerService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final WorkflowRepository workflowRepository;
+    private final WorkflowLogRepository workflowLogRepository;
+    private final WorkflowEngine engine;
+    private final WorkflowExecutorService executor;
+
+    public WorkflowRunnerService(
+            WorkflowRepository workflowRepository,
+            WorkflowLogRepository workflowLogRepository,
+            WorkflowEngine engine,
+            WorkflowExecutorService executor) {
+        this.workflowRepository = workflowRepository;
+        this.workflowLogRepository = workflowLogRepository;
+        this.engine = engine;
+        this.executor = executor;
+    }
+
+    /**
+     * Load active workflows for the trigger event, evaluate conditions,
+     * execute actions on the matches, and write audit logs.
+     *
+     * @param triggerEvent the event name, e.g. {@code "ticket.created"}
+     * @param ticket       the ticket being acted on
+     */
+    public void runForEvent(String triggerEvent, Ticket ticket) {
+        List<Workflow> workflows =
+                workflowRepository.findByTriggerEventAndIsActiveTrueOrderByPositionAsc(triggerEvent);
+        if (workflows.isEmpty()) {
+            return;
+        }
+
+        Map<String, String> conditionMap = ticketToConditionMap(ticket);
+
+        for (Workflow wf : workflows) {
+            Instant startedAt = Instant.now();
+            boolean matched = evaluate(wf, conditionMap);
+
+            WorkflowLog logRow = new WorkflowLog();
+            logRow.setWorkflow(wf);
+            logRow.setTicket(ticket);
+            logRow.setTriggerEvent(triggerEvent);
+            logRow.setConditionsMatched(matched);
+            logRow.setStartedAt(startedAt);
+            logRow = workflowLogRepository.save(logRow);
+
+            if (!matched) {
+                continue;
+            }
+
+            try {
+                List<Map<String, Object>> executed = executor.execute(ticket, wf.getActions());
+                logRow.setActionsExecutedJson(safeSerialize(executed));
+                logRow.setCompletedAt(Instant.now());
+                workflowLogRepository.save(logRow);
+            } catch (RuntimeException ex) {
+                log.error("Workflow #{} ({}) failed on ticket #{}: {}",
+                        wf.getId(), wf.getName(), ticket.getId(), ex.getMessage());
+                logRow.setErrorMessage(ex.getMessage());
+                logRow.setCompletedAt(Instant.now());
+                workflowLogRepository.save(logRow);
+            }
+
+            if (wf.isStopOnMatch()) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Parse the workflow's {@code conditions} JSON and evaluate it
+     * against the ticket field-map. A null/blank conditions payload
+     * matches everything (same rule as NestJS).
+     */
+    private boolean evaluate(Workflow wf, Map<String, String> conditionMap) {
+        String conditionsJson = wf.getConditions();
+        if (conditionsJson == null || conditionsJson.isBlank()) {
+            return true;
+        }
+        try {
+            Map<String, Object> conditions =
+                    MAPPER.readValue(conditionsJson, new TypeReference<Map<String, Object>>() {});
+            return engine.evaluateConditions(conditions, conditionMap);
+        } catch (Exception ex) {
+            log.warn("[WorkflowRunner] bad conditions JSON on workflow #{}: {}",
+                    wf.getId(), ex.getMessage());
+            return false;
+        }
+    }
+
+    private static String safeSerialize(Object value) {
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    /**
+     * Flattens a ticket into a string-keyed, string-valued map for the
+     * condition evaluator (which treats all fields as strings). Relations
+     * and objects are skipped.
+     */
+    private static Map<String, String> ticketToConditionMap(Ticket ticket) {
+        Map<String, String> map = new HashMap<>();
+        put(map, "id", ticket.getId());
+        put(map, "subject", ticket.getSubject());
+        put(map, "body", ticket.getBody());
+        put(map, "ticket_number", ticket.getTicketNumber());
+        put(map, "requester_name", ticket.getRequesterName());
+        put(map, "requester_email", ticket.getRequesterEmail());
+        if (ticket.getPriority() != null) {
+            map.put("priority", ticket.getPriority().name().toLowerCase());
+        }
+        if (ticket.getStatus() != null) {
+            map.put("status", ticket.getStatus().name().toLowerCase());
+        }
+        if (ticket.getDepartment() != null && ticket.getDepartment().getId() != null) {
+            map.put("department_id", String.valueOf(ticket.getDepartment().getId()));
+        }
+        if (ticket.getAssignedAgent() != null && ticket.getAssignedAgent().getId() != null) {
+            map.put("assigned_agent_id", String.valueOf(ticket.getAssignedAgent().getId()));
+        }
+        return map;
+    }
+
+    private static void put(Map<String, String> map, String key, Object value) {
+        if (value != null) {
+            map.put(key, String.valueOf(value));
+        }
+    }
+}

--- a/src/test/java/dev/escalated/services/WorkflowRunnerServiceTest.java
+++ b/src/test/java/dev/escalated/services/WorkflowRunnerServiceTest.java
@@ -1,0 +1,204 @@
+package dev.escalated.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketPriority;
+import dev.escalated.models.TicketStatus;
+import dev.escalated.models.Workflow;
+import dev.escalated.models.WorkflowLog;
+import dev.escalated.repositories.WorkflowLogRepository;
+import dev.escalated.repositories.WorkflowRepository;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link WorkflowRunnerService}.
+ *
+ * <p>Uses a real {@link WorkflowEngine} + spy'd {@link WorkflowExecutorService}
+ * so the condition-evaluation / log-writing orchestration path is exercised
+ * end-to-end. Mirrors the NestJS reference {@code workflow-runner.service.ts}.
+ */
+@ExtendWith(MockitoExtension.class)
+class WorkflowRunnerServiceTest {
+
+    @Mock private WorkflowRepository workflowRepository;
+    @Mock private WorkflowLogRepository workflowLogRepository;
+    @Mock private WorkflowExecutorService executor;
+
+    private WorkflowRunnerService runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = new WorkflowRunnerService(
+                workflowRepository, workflowLogRepository, new WorkflowEngine(), executor);
+        when(workflowLogRepository.save(any(WorkflowLog.class)))
+                .thenAnswer(inv -> {
+                    WorkflowLog l = inv.getArgument(0);
+                    if (l.getId() == null) {
+                        l.setId(1L);
+                    }
+                    return l;
+                });
+    }
+
+    private Ticket newTicket() {
+        Ticket t = new Ticket();
+        t.setId(1L);
+        t.setSubject("Help");
+        t.setPriority(TicketPriority.MEDIUM);
+        t.setStatus(TicketStatus.OPEN);
+        return t;
+    }
+
+    private Workflow workflow(long id, String name, String conditions, boolean stopOnMatch) {
+        Workflow wf = new Workflow();
+        wf.setId(id);
+        wf.setName(name);
+        wf.setTriggerEvent("ticket.created");
+        wf.setConditions(conditions);
+        wf.setActions("[{\"type\":\"add_note\",\"value\":\"hi\"}]");
+        wf.setActive(true);
+        wf.setStopOnMatch(stopOnMatch);
+        return wf;
+    }
+
+    @Test
+    void runForEvent_noMatchingWorkflows_doesNothing() {
+        when(workflowRepository.findByTriggerEventAndIsActiveTrueOrderByPositionAsc("ticket.created"))
+                .thenReturn(List.of());
+
+        runner.runForEvent("ticket.created", newTicket());
+
+        verify(executor, never()).execute(any(), anyString());
+        verify(workflowLogRepository, never()).save(any(WorkflowLog.class));
+    }
+
+    @Test
+    void runForEvent_matched_executesAndLogs() {
+        Workflow wf = workflow(1L, "A", null, false); // null conditions = match all
+        when(workflowRepository.findByTriggerEventAndIsActiveTrueOrderByPositionAsc(anyString()))
+                .thenReturn(List.of(wf));
+        when(executor.execute(any(Ticket.class), anyString()))
+                .thenReturn(List.of(Map.of("type", "add_note", "value", "hi")));
+
+        runner.runForEvent("ticket.created", newTicket());
+
+        verify(executor, times(1)).execute(any(Ticket.class), anyString());
+        ArgumentCaptor<WorkflowLog> captor = ArgumentCaptor.forClass(WorkflowLog.class);
+        // One save for the initial row + one update after execution.
+        verify(workflowLogRepository, times(2)).save(captor.capture());
+        WorkflowLog finalLog = captor.getAllValues().get(1);
+        assertThat(finalLog.isConditionsMatched()).isTrue();
+        assertThat(finalLog.getCompletedAt()).isNotNull();
+        assertThat(finalLog.getErrorMessage()).isNull();
+        assertThat(finalLog.getActionsExecutedJson()).contains("add_note");
+    }
+
+    @Test
+    void runForEvent_unmatched_logsButDoesNotExecute() {
+        // Conditions require status=closed, ticket is open.
+        String conditions = "{\"all\":[{\"field\":\"status\",\"operator\":\"equals\",\"value\":\"closed\"}]}";
+        Workflow wf = workflow(1L, "A", conditions, false);
+        when(workflowRepository.findByTriggerEventAndIsActiveTrueOrderByPositionAsc(anyString()))
+                .thenReturn(List.of(wf));
+
+        runner.runForEvent("ticket.created", newTicket());
+
+        verify(executor, never()).execute(any(), anyString());
+        verify(workflowLogRepository, times(1)).save(any(WorkflowLog.class));
+    }
+
+    @Test
+    void runForEvent_malformedConditionsJson_doesNotMatch() {
+        Workflow wf = workflow(1L, "A", "{ not: valid json", false);
+        when(workflowRepository.findByTriggerEventAndIsActiveTrueOrderByPositionAsc(anyString()))
+                .thenReturn(List.of(wf));
+
+        runner.runForEvent("ticket.created", newTicket());
+
+        verify(executor, never()).execute(any(), anyString());
+        ArgumentCaptor<WorkflowLog> captor = ArgumentCaptor.forClass(WorkflowLog.class);
+        verify(workflowLogRepository).save(captor.capture());
+        assertThat(captor.getValue().isConditionsMatched()).isFalse();
+    }
+
+    @Test
+    void runForEvent_stopOnMatch_haltsAfterFirstMatch() {
+        Workflow first = workflow(1L, "first", null, true);   // stopOnMatch = true
+        Workflow second = workflow(2L, "second", null, false);
+        when(workflowRepository.findByTriggerEventAndIsActiveTrueOrderByPositionAsc(anyString()))
+                .thenReturn(List.of(first, second));
+        when(executor.execute(any(Ticket.class), anyString()))
+                .thenReturn(List.of());
+
+        runner.runForEvent("ticket.created", newTicket());
+
+        // Only the first workflow should have been executed.
+        verify(executor, times(1)).execute(any(), anyString());
+    }
+
+    @Test
+    void runForEvent_stopOnMatch_onlyAppliesOnMatch() {
+        // first is stop_on_match=true but doesn't match (status=closed condition).
+        // Second should still run.
+        String failingCond = "{\"all\":[{\"field\":\"status\",\"operator\":\"equals\",\"value\":\"closed\"}]}";
+        Workflow first = workflow(1L, "first", failingCond, true);
+        Workflow second = workflow(2L, "second", null, false);
+        when(workflowRepository.findByTriggerEventAndIsActiveTrueOrderByPositionAsc(anyString()))
+                .thenReturn(List.of(first, second));
+        when(executor.execute(any(Ticket.class), anyString()))
+                .thenReturn(List.of());
+
+        runner.runForEvent("ticket.created", newTicket());
+
+        // second workflow matched (null conditions) and ran.
+        verify(executor, times(1)).execute(any(), anyString());
+    }
+
+    @Test
+    void runForEvent_executorFailureIsCaughtAndStamped() {
+        Workflow wf = workflow(1L, "A", null, false);
+        when(workflowRepository.findByTriggerEventAndIsActiveTrueOrderByPositionAsc(anyString()))
+                .thenReturn(List.of(wf));
+        when(executor.execute(any(Ticket.class), anyString()))
+                .thenThrow(new RuntimeException("db offline"));
+
+        // Should not throw — failure is stamped on the log row.
+        runner.runForEvent("ticket.created", newTicket());
+
+        ArgumentCaptor<WorkflowLog> captor = ArgumentCaptor.forClass(WorkflowLog.class);
+        verify(workflowLogRepository, times(2)).save(captor.capture());
+        WorkflowLog finalLog = captor.getAllValues().get(1);
+        assertThat(finalLog.getErrorMessage()).isEqualTo("db offline");
+        assertThat(finalLog.getCompletedAt()).isNotNull();
+    }
+
+    @Test
+    void runForEvent_multipleWorkflows_failureDoesNotBlockLater() {
+        Workflow first = workflow(1L, "first", null, false);
+        Workflow second = workflow(2L, "second", null, false);
+        when(workflowRepository.findByTriggerEventAndIsActiveTrueOrderByPositionAsc(anyString()))
+                .thenReturn(List.of(first, second));
+        when(executor.execute(any(Ticket.class), anyString()))
+                .thenThrow(new RuntimeException("first failed"))
+                .thenReturn(List.of());
+
+        runner.runForEvent("ticket.created", newTicket());
+
+        // Both workflows should have been tried despite the first one failing.
+        verify(executor, times(2)).execute(any(), anyString());
+    }
+}


### PR DESCRIPTION
## Summary

Ports the NestJS `workflow-runner.service.ts` to Spring. This is the **orchestrator** piece that loads active Workflows for a trigger event (in `position` order), evaluates conditions via `WorkflowEngine`, dispatches matches to `WorkflowExecutorService`, and writes a `WorkflowLog` audit row per Workflow considered.

## Behavior

- Honors `stop_on_match` — but **only when the workflow actually matches** (failing workflows don't halt the chain)
- Catches executor failures so one bad workflow never blocks the rest (failure stamped on the log row via `errorMessage`)
- Malformed conditions JSON logs a warning and treats the workflow as non-matching
- Null/blank conditions match all tickets (matches NestJS semantics)

## Scope

**Runner only.** Follow-up PR:

- Spring `@EventListener` that bridges `TicketEvent` → `runForEvent`

## Dependencies

- **Stacked on #21** (`feat/workflow-executor`). Will rebase onto `main` once #21 merges.

## Test plan

- [x] 8 unit tests covering happy-path, no-match, stop-on-match semantics, malformed conditions, executor-failure isolation
- [ ] CI green: `test`, `checkstyle`