### PR TITLE
feat(email): add MessageIdUtil for RFC 5322 threading + signed Reply-To

### DIFF
--- a/src/main/java/dev/escalated/services/email/MessageIdUtil.java
+++ b/src/main/java/dev/escalated/services/email/MessageIdUtil.java
@@ -1,0 +1,108 @@
+package dev.escalated.services.email;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Pure helpers for RFC 5322 Message-ID threading and signed Reply-To
+ * addresses. Mirrors the NestJS reference
+ * <c>escalated-nestjs/src/services/email/message-id.ts</c>.
+ *
+ * <p>Message-ID format:
+ * <ul>
+ *   <li><code>&lt;ticket-{ticketId}@{domain}&gt;</code> — initial ticket email</li>
+ *   <li><code>&lt;ticket-{ticketId}-reply-{replyId}@{domain}&gt;</code> — agent reply</li>
+ * </ul>
+ *
+ * <p>Signed Reply-To format:
+ * <code>reply+{ticketId}.{hmac8}@{domain}</code>
+ *
+ * <p>The signed Reply-To carries identity even when clients strip our
+ * Message-ID / In-Reply-To headers — inbound provider webhook verifies
+ * the signature before routing the reply to the ticket.
+ */
+public final class MessageIdUtil {
+
+    private static final Pattern TICKET_ID_IN_MSG = Pattern.compile("ticket-(\\d+)(?:-reply-\\d+)?@", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REPLY_LOCAL_PART = Pattern.compile("^reply\\+(\\d+)\\.([a-f0-9]{8})$", Pattern.CASE_INSENSITIVE);
+
+    private MessageIdUtil() {
+        // static helpers only
+    }
+
+    /**
+     * Build an RFC 5322 Message-ID. Pass {@code null} for {@code replyId}
+     * on the initial ticket email; the tail "-reply-{id}" is appended
+     * only when {@code replyId} is non-null.
+     */
+    public static String buildMessageId(long ticketId, Long replyId, String domain) {
+        String body = replyId != null ? "ticket-" + ticketId + "-reply-" + replyId : "ticket-" + ticketId;
+        return "<" + body + "@" + domain + ">";
+    }
+
+    /**
+     * Extract the ticket id from a Message-ID we issued. Accepts the
+     * header value with or without angle brackets. Returns
+     * {@link Optional#empty()} when the input doesn't match our shape.
+     */
+    public static Optional<Long> parseTicketIdFromMessageId(String raw) {
+        if (raw == null) return Optional.empty();
+        Matcher m = TICKET_ID_IN_MSG.matcher(raw);
+        if (!m.find()) return Optional.empty();
+        try {
+            return Optional.of(Long.parseLong(m.group(1)));
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Build a signed Reply-To address. The 8-character HMAC-SHA256
+     * signature over the ticket id + secret prevents tampering.
+     */
+    public static String buildReplyTo(long ticketId, String secret, String domain) {
+        return "reply+" + ticketId + "." + sign(ticketId, secret) + "@" + domain;
+    }
+
+    /**
+     * Verify a full reply-to address (local@domain) or just the local
+     * part. Returns the ticket id on success.
+     */
+    public static Optional<Long> verifyReplyTo(String address, String secret) {
+        if (address == null) return Optional.empty();
+        int at = address.indexOf('@');
+        String local = at > 0 ? address.substring(0, at) : address;
+        Matcher m = REPLY_LOCAL_PART.matcher(local);
+        if (!m.matches()) return Optional.empty();
+        long ticketId;
+        try {
+            ticketId = Long.parseLong(m.group(1));
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+        String expected = sign(ticketId, secret);
+        if (!expected.equalsIgnoreCase(m.group(2))) {
+            return Optional.empty();
+        }
+        return Optional.of(ticketId);
+    }
+
+    private static String sign(long ticketId, String secret) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] digest = mac.doFinal(Long.toString(ticketId).getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(16);
+            for (int i = 0; i < 4; i++) {
+                hex.append(String.format("%02x", digest[i]));
+            }
+            return hex.toString();
+        } catch (Exception ex) {
+            throw new IllegalStateException("HMAC-SHA256 unavailable", ex);
+        }
+    }
+}

--- a/src/test/java/dev/escalated/services/email/MessageIdUtilTest.java
+++ b/src/test/java/dev/escalated/services/email/MessageIdUtilTest.java
@@ -1,0 +1,119 @@
+package dev.escalated.services.email;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link MessageIdUtil}. Mirrors the NestJS test suite
+ * for {@code message-id.ts}. Pure functions — no Spring context.
+ */
+class MessageIdUtilTest {
+
+    private static final String DOMAIN = "support.example.com";
+    private static final String SECRET = "test-secret-long-enough-for-hmac";
+
+    @Test
+    void buildMessageId_initialTicket_usesTicketForm() {
+        String id = MessageIdUtil.buildMessageId(42, null, DOMAIN);
+        assertThat(id).isEqualTo("<ticket-42@support.example.com>");
+    }
+
+    @Test
+    void buildMessageId_replyForm_appendsReplyId() {
+        String id = MessageIdUtil.buildMessageId(42, 7L, DOMAIN);
+        assertThat(id).isEqualTo("<ticket-42-reply-7@support.example.com>");
+    }
+
+    @Test
+    void parseTicketIdFromMessageId_roundTripsBuiltId() {
+        String initial = MessageIdUtil.buildMessageId(42, null, DOMAIN);
+        String reply = MessageIdUtil.buildMessageId(42, 7L, DOMAIN);
+
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId(initial)).contains(42L);
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId(reply)).contains(42L);
+    }
+
+    @Test
+    void parseTicketIdFromMessageId_acceptsValueWithoutBrackets() {
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("ticket-99@example.com")).contains(99L);
+    }
+
+    @Test
+    void parseTicketIdFromMessageId_returnsEmptyForUnrelatedInput() {
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId(null)).isEmpty();
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("")).isEmpty();
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("<random@mail.com>")).isEmpty();
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("ticket-abc@example.com")).isEmpty();
+    }
+
+    @Test
+    void buildReplyTo_isStableForSameInputs() {
+        String first = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String again = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+
+        assertThat(first).isEqualTo(again);
+        assertThat(first).matches("reply\\+42\\.[a-f0-9]{8}@support\\.example\\.com");
+    }
+
+    @Test
+    void buildReplyTo_differentTicketsProduceDifferentSignatures() {
+        String a = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String b = MessageIdUtil.buildReplyTo(43, SECRET, DOMAIN);
+
+        // Local parts differ in both the ticket id and the signature.
+        String aLocal = a.substring(0, a.indexOf('@'));
+        String bLocal = b.substring(0, b.indexOf('@'));
+        assertThat(aLocal).isNotEqualTo(bLocal);
+    }
+
+    @Test
+    void verifyReplyTo_roundTripsBuiltAddress() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        assertThat(MessageIdUtil.verifyReplyTo(address, SECRET)).contains(42L);
+    }
+
+    @Test
+    void verifyReplyTo_acceptsLocalPartOnly() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String local = address.substring(0, address.indexOf('@'));
+        assertThat(MessageIdUtil.verifyReplyTo(local, SECRET)).contains(42L);
+    }
+
+    @Test
+    void verifyReplyTo_rejectsTamperedSignature() {
+        // Build a valid address, then flip one signature char.
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        int at = address.indexOf('@');
+        String local = address.substring(0, at);
+        String tampered = local.substring(0, local.length() - 1)
+                + (local.charAt(local.length() - 1) == '0' ? '1' : '0')
+                + address.substring(at);
+
+        assertThat(MessageIdUtil.verifyReplyTo(tampered, SECRET)).isEmpty();
+    }
+
+    @Test
+    void verifyReplyTo_rejectsWrongSecret() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        assertThat(MessageIdUtil.verifyReplyTo(address, "different-secret")).isEmpty();
+    }
+
+    @Test
+    void verifyReplyTo_rejectsMalformedInput() {
+        Optional<Long> empty = Optional.empty();
+        assertThat(MessageIdUtil.verifyReplyTo(null, SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("", SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("alice@example.com", SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("reply@example.com", SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("reply+abc.deadbeef@example.com", SECRET)).isEqualTo(empty);
+    }
+
+    @Test
+    void verifyReplyTo_isCaseInsensitiveOnHex() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String upper = address.toUpperCase();
+        assertThat(MessageIdUtil.verifyReplyTo(upper, SECRET)).contains(42L);
+    }
+}


### PR DESCRIPTION
## Summary

Ports the NestJS `email/message-id.ts` helpers to Spring. Pure utility class, no runtime dependencies beyond the JDK's `javax.crypto`.

## API

- `buildMessageId(ticketId, replyId, domain)` — RFC 5322 Message-ID
  - `<ticket-{id}@{domain}>` for initial ticket emails
  - `<ticket-{id}-reply-{replyId}@{domain}>` for agent replies
- `parseTicketIdFromMessageId(raw)` — extract ticket id from header value (accepts with or without angle brackets)
- `buildReplyTo(ticketId, secret, domain)` — signed Reply-To of the form `reply+{id}.{hmac8}@{domain}`
- `verifyReplyTo(address, secret)` — inbound webhook check; returns ticket id on match

## Why signed Reply-To

Even when clients strip our `Message-ID` / `In-Reply-To` headers, the Reply-To address still carries ticket identity — the 8-char HMAC-SHA256 prefix prevents forgery.

## Scope

**Utility only.** Follow-up PR will:

1. Wire `MessageIdUtil` into `EmailService.sendEmail` (Message-ID + Reply-To headers)
2. Add an `EscalatedProperties.Email` config block for `domain` + `inboundSecret`
3. Add an inbound webhook / controller that calls `verifyReplyTo`

## Test plan

- [x] 13 unit tests covering buildMessageId (initial + reply), parseTicketIdFromMessageId (round-trip + malformed), buildReplyTo (stable, unique per ticket), verifyReplyTo (tamper rejection, wrong secret, local-part-only, case-insensitive hex)
- [ ] CI green: `test`, `checkstyle`