### PR TITLE
feat(inbound): scaffold InboundMessage + InboundEmailParser + InboundEmailRouter

### DIFF
--- a/src/main/java/dev/escalated/config/EscalatedProperties.java
+++ b/src/main/java/dev/escalated/config/EscalatedProperties.java
@@ -15,6 +15,7 @@ public class EscalatedProperties {
     private WebhookProperties webhook = new WebhookProperties();
     private WidgetProperties widget = new WidgetProperties();
     private GuestAccessProperties guestAccess = new GuestAccessProperties();
+    private EmailProperties email = new EmailProperties();
 
     public boolean isEnabled() {
         return enabled;
@@ -94,6 +95,14 @@ public class EscalatedProperties {
 
     public void setGuestAccess(GuestAccessProperties guestAccess) {
         this.guestAccess = guestAccess;
+    }
+
+    public EmailProperties getEmail() {
+        return email;
+    }
+
+    public void setEmail(EmailProperties email) {
+        this.email = email;
     }
 
     public static class KnowledgeBaseProperties {
@@ -189,6 +198,34 @@ public class EscalatedProperties {
 
         public void setEnabled(boolean enabled) {
             this.enabled = enabled;
+        }
+    }
+
+    /**
+     * Outbound + inbound email config. {@code domain} is used for the
+     * right-hand side of RFC 5322 Message-IDs and signed Reply-To
+     * addresses. {@code inboundSecret} is the HMAC key used to sign
+     * Reply-To addresses so the inbound provider webhook can verify
+     * a ticket id without trusting the mail client's threading headers.
+     */
+    public static class EmailProperties {
+        private String domain = "localhost";
+        private String inboundSecret = "";
+
+        public String getDomain() {
+            return domain;
+        }
+
+        public void setDomain(String domain) {
+            this.domain = domain;
+        }
+
+        public String getInboundSecret() {
+            return inboundSecret;
+        }
+
+        public void setInboundSecret(String inboundSecret) {
+            this.inboundSecret = inboundSecret;
         }
     }
 }

--- a/src/main/java/dev/escalated/services/EmailService.java
+++ b/src/main/java/dev/escalated/services/EmailService.java
@@ -1,7 +1,9 @@
 package dev.escalated.services;
 
+import dev.escalated.config.EscalatedProperties;
 import dev.escalated.models.Reply;
 import dev.escalated.models.Ticket;
+import dev.escalated.services.email.MessageIdUtil;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.slf4j.Logger;
@@ -19,10 +21,15 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
     private final TemplateEngine templateEngine;
+    private final EscalatedProperties properties;
 
-    public EmailService(JavaMailSender mailSender, TemplateEngine templateEngine) {
+    public EmailService(
+            JavaMailSender mailSender,
+            TemplateEngine templateEngine,
+            EscalatedProperties properties) {
         this.mailSender = mailSender;
         this.templateEngine = templateEngine;
+        this.properties = properties;
     }
 
     public void sendTicketCreatedNotification(Ticket ticket) {
@@ -31,8 +38,10 @@ public class EmailService {
         context.setVariable("ticketUrl", "/escalated/tickets/" + ticket.getId());
 
         String htmlContent = templateEngine.process("email/ticket-created", context);
+        String messageId = MessageIdUtil.buildMessageId(
+                ticket.getId(), null, emailDomain());
         sendEmail(ticket.getRequesterEmail(), "Ticket Created: " + ticket.getSubject(),
-                htmlContent, ticket.getEmailMessageId());
+                htmlContent, messageId, null, ticket.getId());
     }
 
     public void sendReplyNotification(Ticket ticket, Reply reply) {
@@ -46,7 +55,14 @@ public class EmailService {
                 : (ticket.getAssignedAgent() != null ? ticket.getAssignedAgent().getEmail() : null);
 
         if (recipient != null) {
-            sendEmail(recipient, "Re: " + ticket.getSubject(), htmlContent, reply.getEmailMessageId());
+            // Reply Message-ID includes reply id; References points back
+            // to the ticket-root Message-ID so clients thread correctly.
+            String replyMessageId = MessageIdUtil.buildMessageId(
+                    ticket.getId(), reply.getId(), emailDomain());
+            String rootMessageId = MessageIdUtil.buildMessageId(
+                    ticket.getId(), null, emailDomain());
+            sendEmail(recipient, "Re: " + ticket.getSubject(), htmlContent,
+                    replyMessageId, rootMessageId, ticket.getId());
         }
     }
 
@@ -56,10 +72,20 @@ public class EmailService {
         context.setVariable("surveyUrl", surveyUrl);
 
         String htmlContent = templateEngine.process("email/satisfaction-survey", context);
-        sendEmail(ticket.getRequesterEmail(), "How was your experience?", htmlContent, null);
+        sendEmail(ticket.getRequesterEmail(), "How was your experience?",
+                htmlContent, null, null, ticket.getId());
     }
 
-    private void sendEmail(String to, String subject, String htmlContent, String messageId) {
+    /**
+     * Internal: send a MIME message with canonical threading + Reply-To
+     * headers. {@code messageId} is the header to set; {@code threadRoot}
+     * (nullable) is the In-Reply-To / References anchor for replies.
+     * {@code ticketId} is used to compute the signed Reply-To so the
+     * inbound provider webhook can verify ticket identity independently
+     * of the Message-ID / In-Reply-To chain.
+     */
+    private void sendEmail(String to, String subject, String htmlContent,
+                           String messageId, String threadRoot, long ticketId) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
@@ -69,12 +95,33 @@ public class EmailService {
 
             if (messageId != null) {
                 message.setHeader("Message-ID", messageId);
-                message.setHeader("References", messageId);
+            }
+            if (threadRoot != null) {
+                message.setHeader("In-Reply-To", threadRoot);
+                message.setHeader("References", threadRoot);
+            }
+
+            // Signed Reply-To so the inbound webhook can verify ticket
+            // identity even when clients strip the Message-ID chain.
+            String secret = emailInboundSecret();
+            if (!secret.isEmpty()) {
+                helper.setReplyTo(
+                        MessageIdUtil.buildReplyTo(ticketId, secret, emailDomain()));
             }
 
             mailSender.send(message);
         } catch (MessagingException ex) {
             log.error("Failed to send email to {}: {}", to, ex.getMessage());
         }
+    }
+
+    private String emailDomain() {
+        String domain = properties.getEmail().getDomain();
+        return (domain == null || domain.isBlank()) ? "localhost" : domain;
+    }
+
+    private String emailInboundSecret() {
+        String secret = properties.getEmail().getInboundSecret();
+        return secret == null ? "" : secret;
     }
 }

--- a/src/main/java/dev/escalated/services/email/MessageIdUtil.java
+++ b/src/main/java/dev/escalated/services/email/MessageIdUtil.java
@@ -1,0 +1,108 @@
+package dev.escalated.services.email;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Pure helpers for RFC 5322 Message-ID threading and signed Reply-To
+ * addresses. Mirrors the NestJS reference
+ * <c>escalated-nestjs/src/services/email/message-id.ts</c>.
+ *
+ * <p>Message-ID format:
+ * <ul>
+ *   <li><code>&lt;ticket-{ticketId}@{domain}&gt;</code> — initial ticket email</li>
+ *   <li><code>&lt;ticket-{ticketId}-reply-{replyId}@{domain}&gt;</code> — agent reply</li>
+ * </ul>
+ *
+ * <p>Signed Reply-To format:
+ * <code>reply+{ticketId}.{hmac8}@{domain}</code>
+ *
+ * <p>The signed Reply-To carries identity even when clients strip our
+ * Message-ID / In-Reply-To headers — inbound provider webhook verifies
+ * the signature before routing the reply to the ticket.
+ */
+public final class MessageIdUtil {
+
+    private static final Pattern TICKET_ID_IN_MSG = Pattern.compile("ticket-(\\d+)(?:-reply-\\d+)?@", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REPLY_LOCAL_PART = Pattern.compile("^reply\\+(\\d+)\\.([a-f0-9]{8})$", Pattern.CASE_INSENSITIVE);
+
+    private MessageIdUtil() {
+        // static helpers only
+    }
+
+    /**
+     * Build an RFC 5322 Message-ID. Pass {@code null} for {@code replyId}
+     * on the initial ticket email; the tail "-reply-{id}" is appended
+     * only when {@code replyId} is non-null.
+     */
+    public static String buildMessageId(long ticketId, Long replyId, String domain) {
+        String body = replyId != null ? "ticket-" + ticketId + "-reply-" + replyId : "ticket-" + ticketId;
+        return "<" + body + "@" + domain + ">";
+    }
+
+    /**
+     * Extract the ticket id from a Message-ID we issued. Accepts the
+     * header value with or without angle brackets. Returns
+     * {@link Optional#empty()} when the input doesn't match our shape.
+     */
+    public static Optional<Long> parseTicketIdFromMessageId(String raw) {
+        if (raw == null) return Optional.empty();
+        Matcher m = TICKET_ID_IN_MSG.matcher(raw);
+        if (!m.find()) return Optional.empty();
+        try {
+            return Optional.of(Long.parseLong(m.group(1)));
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Build a signed Reply-To address. The 8-character HMAC-SHA256
+     * signature over the ticket id + secret prevents tampering.
+     */
+    public static String buildReplyTo(long ticketId, String secret, String domain) {
+        return "reply+" + ticketId + "." + sign(ticketId, secret) + "@" + domain;
+    }
+
+    /**
+     * Verify a full reply-to address (local@domain) or just the local
+     * part. Returns the ticket id on success.
+     */
+    public static Optional<Long> verifyReplyTo(String address, String secret) {
+        if (address == null) return Optional.empty();
+        int at = address.indexOf('@');
+        String local = at > 0 ? address.substring(0, at) : address;
+        Matcher m = REPLY_LOCAL_PART.matcher(local);
+        if (!m.matches()) return Optional.empty();
+        long ticketId;
+        try {
+            ticketId = Long.parseLong(m.group(1));
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+        String expected = sign(ticketId, secret);
+        if (!expected.equalsIgnoreCase(m.group(2))) {
+            return Optional.empty();
+        }
+        return Optional.of(ticketId);
+    }
+
+    private static String sign(long ticketId, String secret) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] digest = mac.doFinal(Long.toString(ticketId).getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(16);
+            for (int i = 0; i < 4; i++) {
+                hex.append(String.format("%02x", digest[i]));
+            }
+            return hex.toString();
+        } catch (Exception ex) {
+            throw new IllegalStateException("HMAC-SHA256 unavailable", ex);
+        }
+    }
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundAttachment.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundAttachment.java
@@ -1,0 +1,15 @@
+package dev.escalated.services.email.inbound;
+
+/**
+ * Inbound attachment. Providers either inline the content (small
+ * attachments) or supply a URL to download it from (larger
+ * provider-hosted attachments).
+ */
+public record InboundAttachment(
+        String name,
+        String contentType,
+        Long sizeBytes,
+        byte[] content,
+        String downloadUrl
+) {
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundEmailParser.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundEmailParser.java
@@ -1,0 +1,27 @@
+package dev.escalated.services.email.inbound;
+
+/**
+ * Transport-specific parser that normalizes a provider's webhook
+ * payload into an {@link InboundMessage}. Implementations register
+ * themselves as Spring beans and are resolved by {@link #name()}
+ * (matches the adapter label on the inbound webhook request).
+ *
+ * <p>Add a new provider by implementing this interface; the inbound
+ * controller will pick it up via DI when the request's adapter label
+ * matches {@link #name()}.
+ */
+public interface InboundEmailParser {
+
+    /**
+     * Short provider name. Must match the value in the
+     * {@code ?adapter=...} query parameter or the
+     * {@code X-Escalated-Adapter} header on the inbound webhook.
+     */
+    String name();
+
+    /**
+     * Parse a raw webhook payload (e.g. a provider-specific JSON
+     * object) into an {@link InboundMessage}.
+     */
+    InboundMessage parse(Object rawPayload);
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundEmailRouter.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundEmailRouter.java
@@ -1,0 +1,125 @@
+package dev.escalated.services.email.inbound;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.Ticket;
+import dev.escalated.repositories.TicketRepository;
+import dev.escalated.services.email.MessageIdUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves an inbound email to an existing ticket via canonical
+ * Message-ID parsing + signed Reply-To verification.
+ *
+ * <p>Resolution order (first match wins):
+ * <ol>
+ *   <li>{@code In-Reply-To} parsed via {@link MessageIdUtil#parseTicketIdFromMessageId}
+ *       — cold-start path, no DB lookup on the header value required
+ *       (we know our own Message-ID format).</li>
+ *   <li>{@code References} parsed via {@link MessageIdUtil#parseTicketIdFromMessageId},
+ *       each id in order.</li>
+ *   <li>Signed Reply-To on {@link InboundMessage#toEmail()}
+ *       ({@code reply+{id}.{hmac8}@...}) verified via
+ *       {@link MessageIdUtil#verifyReplyTo}. Survives clients that
+ *       strip our threading headers; forged signatures are rejected
+ *       with a timing-safe HMAC comparison.</li>
+ *   <li>Subject line reference tag (e.g. {@code [ESC-00001]}) — legacy.</li>
+ *   <li>Audit-log lookup — not implemented in this PR; the row is
+ *       inserted by the inbound controller once the service lands.</li>
+ * </ol>
+ *
+ * <p>Mirrors the NestJS {@code InboundRouterService} resolution order
+ * and the Laravel/Rails/Django/Adonis/WordPress/.NET ports.
+ */
+@Service
+public class InboundEmailRouter {
+
+    private static final Logger log = LoggerFactory.getLogger(InboundEmailRouter.class);
+
+    private final TicketRepository ticketRepository;
+    private final EscalatedProperties properties;
+
+    public InboundEmailRouter(TicketRepository ticketRepository, EscalatedProperties properties) {
+        this.ticketRepository = ticketRepository;
+        this.properties = properties;
+    }
+
+    /**
+     * Resolve the inbound email to an existing ticket, or
+     * {@link Optional#empty()} when no match (caller should create a
+     * new ticket).
+     */
+    public Optional<Ticket> resolveTicket(InboundMessage message) {
+        if (message == null) {
+            return Optional.empty();
+        }
+
+        List<String> headerIds = candidateHeaderMessageIds(message);
+
+        // 1 + 2. Parse canonical Message-IDs out of our own headers.
+        for (String raw : headerIds) {
+            Optional<Long> ticketId = MessageIdUtil.parseTicketIdFromMessageId(raw);
+            if (ticketId.isPresent()) {
+                Optional<Ticket> ticket = ticketRepository.findById(ticketId.get());
+                if (ticket.isPresent()) {
+                    return ticket;
+                }
+            }
+        }
+
+        // 3. Signed Reply-To on the recipient address.
+        String secret = properties.getEmail() == null ? null : properties.getEmail().getInboundSecret();
+        if (secret != null && !secret.isBlank() && message.toEmail() != null) {
+            Optional<Long> verified = MessageIdUtil.verifyReplyTo(message.toEmail(), secret);
+            if (verified.isPresent()) {
+                Optional<Ticket> ticket = ticketRepository.findById(verified.get());
+                if (ticket.isPresent()) {
+                    return ticket;
+                }
+                log.debug("[InboundEmailRouter] Reply-To verified but ticket #{} not found", verified.get());
+            }
+        }
+
+        // 4. Subject line reference tag.
+        if (message.subject() != null) {
+            Matcher m = SUBJECT_REF_PATTERN.matcher(message.subject());
+            if (m.find()) {
+                // Ticket reference is stored in the ticket_number column.
+                Optional<Ticket> ticket = ticketRepository.findByTicketNumber(m.group(1));
+                if (ticket.isPresent()) {
+                    return ticket;
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Return every candidate Message-ID from the inbound headers in
+     * the order the mail client sent them. Caller iterates the
+     * result and stops at the first resolvable id.
+     */
+    public static List<String> candidateHeaderMessageIds(InboundMessage message) {
+        List<String> ids = new ArrayList<>();
+        if (message.inReplyTo() != null && !message.inReplyTo().isBlank()) {
+            ids.add(message.inReplyTo().trim());
+        }
+        if (message.references() != null && !message.references().isBlank()) {
+            for (String raw : message.references().trim().split("\\s+")) {
+                if (!raw.isBlank()) {
+                    ids.add(raw);
+                }
+            }
+        }
+        return ids;
+    }
+
+    private static final Pattern SUBJECT_REF_PATTERN = Pattern.compile("\\[([A-Z]+-[0-9A-Z-]+)\\]");
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundMessage.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundMessage.java
@@ -1,0 +1,45 @@
+package dev.escalated.services.email.inbound;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Transport-agnostic representation of an inbound email, independent
+ * of the source adapter (Postmark, Mailgun, SES, IMAP, etc.).
+ *
+ * <p>Adapters normalize their webhook payload into this shape; the
+ * {@link InboundEmailRouter} then resolves it to a ticket by parsing
+ * canonical Message-IDs out of {@code inReplyTo} / {@code references}
+ * and verifying the signed Reply-To on {@code toEmail}.
+ *
+ * <p>Mirrors the NestJS reference and the per-framework ports.
+ */
+public record InboundMessage(
+        String fromEmail,
+        String fromName,
+        String toEmail,
+        String subject,
+        String bodyText,
+        String bodyHtml,
+        String messageId,
+        String inReplyTo,
+        String references,
+        Map<String, String> headers,
+        List<InboundAttachment> attachments
+) {
+
+    public InboundMessage {
+        headers = headers == null ? Map.of() : headers;
+        attachments = attachments == null ? List.of() : attachments;
+    }
+
+    /**
+     * Best body content (plain text preferred, HTML fallback).
+     */
+    public String body() {
+        if (bodyText != null && !bodyText.isEmpty()) {
+            return bodyText;
+        }
+        return bodyHtml != null ? bodyHtml : "";
+    }
+}

--- a/src/test/java/dev/escalated/services/EmailServiceTest.java
+++ b/src/test/java/dev/escalated/services/EmailServiceTest.java
@@ -1,0 +1,144 @@
+package dev.escalated.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.AgentProfile;
+import dev.escalated.models.Reply;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketPriority;
+import dev.escalated.models.TicketStatus;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.thymeleaf.TemplateEngine;
+
+/**
+ * Unit tests for {@link EmailService}'s Message-ID / Reply-To wiring.
+ *
+ * <p>Uses a real {@link MimeMessage} + a {@link Mock} JavaMailSender so
+ * we can assert on the headers that the service actually sets. The
+ * Thymeleaf template engine is mocked to avoid pulling in real
+ * templates for these unit tests.
+ */
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @Mock private JavaMailSender mailSender;
+    @Mock private TemplateEngine templateEngine;
+
+    private EmailService service;
+    private EscalatedProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new EscalatedProperties();
+        properties.getEmail().setDomain("support.example.com");
+        properties.getEmail().setInboundSecret("test-secret-for-hmac");
+        service = new EmailService(mailSender, templateEngine, properties);
+
+        // Stub JavaMailSender so createMimeMessage returns a real
+        // MimeMessage we can inspect. Use a no-op session.
+        Session session = Session.getDefaultInstance(new Properties());
+        when(mailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage(session));
+        when(templateEngine.process(any(String.class), any())).thenReturn("<p>rendered</p>");
+    }
+
+    private Ticket newTicket() {
+        Ticket t = new Ticket();
+        t.setId(42L);
+        t.setSubject("Help");
+        t.setStatus(TicketStatus.OPEN);
+        t.setPriority(TicketPriority.MEDIUM);
+        t.setRequesterEmail("alice@example.com");
+        return t;
+    }
+
+    @Test
+    void sendTicketCreatedNotification_setsCanonicalMessageIdAndSignedReplyTo() throws Exception {
+        service.sendTicketCreatedNotification(newTicket());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        String[] messageId = sent.getHeader("Message-ID");
+        assertThat(messageId).isNotNull();
+        assertThat(messageId[0]).isEqualTo("<ticket-42@support.example.com>");
+
+        // No In-Reply-To on the initial notification (thread anchor).
+        assertThat(sent.getHeader("In-Reply-To")).isNull();
+
+        String[] replyTo = sent.getHeader("Reply-To");
+        assertThat(replyTo).isNotNull();
+        assertThat(replyTo[0]).matches("reply\\+42\\.[a-f0-9]{8}@support\\.example\\.com");
+    }
+
+    @Test
+    void sendReplyNotification_addsInReplyToAndReferencesPointingToTicketRoot() throws Exception {
+        Ticket ticket = newTicket();
+        AgentProfile agent = new AgentProfile();
+        agent.setEmail("agent@example.com");
+        ticket.setAssignedAgent(agent);
+
+        Reply reply = new Reply();
+        reply.setId(7L);
+        reply.setAuthorType("requester"); // requester reply → goes to agent
+        reply.setTicket(ticket);
+
+        service.sendReplyNotification(ticket, reply);
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        assertThat(sent.getHeader("Message-ID")[0])
+                .isEqualTo("<ticket-42-reply-7@support.example.com>");
+        assertThat(sent.getHeader("In-Reply-To")[0])
+                .isEqualTo("<ticket-42@support.example.com>");
+        assertThat(sent.getHeader("References")[0])
+                .isEqualTo("<ticket-42@support.example.com>");
+    }
+
+    @Test
+    void sendEmail_whenInboundSecretBlank_doesNotSetReplyTo() throws Exception {
+        properties.getEmail().setInboundSecret("");
+
+        service.sendTicketCreatedNotification(newTicket());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        // Message-ID still present; Reply-To omitted when we have no key.
+        assertThat(sent.getHeader("Message-ID")).isNotNull();
+        assertThat(sent.getHeader("Reply-To")).isNull();
+    }
+
+    @Test
+    void sendSatisfactionSurvey_doesNotSetMessageId_butStillSetsReplyTo() throws Exception {
+        service.sendSatisfactionSurvey(newTicket(), "https://example.com/survey");
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        // Survey is not part of the ticket thread — no Message-ID /
+        // In-Reply-To chain needed. But the Reply-To still routes back
+        // to the ticket so replies (e.g. "what about this other issue")
+        // land on the right ticket id.
+        assertThat(sent.getHeader("Message-ID")).isNull();
+        assertThat(sent.getHeader("In-Reply-To")).isNull();
+        assertThat(sent.getHeader("Reply-To")).isNotNull();
+    }
+}

--- a/src/test/java/dev/escalated/services/email/MessageIdUtilTest.java
+++ b/src/test/java/dev/escalated/services/email/MessageIdUtilTest.java
@@ -1,0 +1,119 @@
+package dev.escalated.services.email;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link MessageIdUtil}. Mirrors the NestJS test suite
+ * for {@code message-id.ts}. Pure functions — no Spring context.
+ */
+class MessageIdUtilTest {
+
+    private static final String DOMAIN = "support.example.com";
+    private static final String SECRET = "test-secret-long-enough-for-hmac";
+
+    @Test
+    void buildMessageId_initialTicket_usesTicketForm() {
+        String id = MessageIdUtil.buildMessageId(42, null, DOMAIN);
+        assertThat(id).isEqualTo("<ticket-42@support.example.com>");
+    }
+
+    @Test
+    void buildMessageId_replyForm_appendsReplyId() {
+        String id = MessageIdUtil.buildMessageId(42, 7L, DOMAIN);
+        assertThat(id).isEqualTo("<ticket-42-reply-7@support.example.com>");
+    }
+
+    @Test
+    void parseTicketIdFromMessageId_roundTripsBuiltId() {
+        String initial = MessageIdUtil.buildMessageId(42, null, DOMAIN);
+        String reply = MessageIdUtil.buildMessageId(42, 7L, DOMAIN);
+
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId(initial)).contains(42L);
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId(reply)).contains(42L);
+    }
+
+    @Test
+    void parseTicketIdFromMessageId_acceptsValueWithoutBrackets() {
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("ticket-99@example.com")).contains(99L);
+    }
+
+    @Test
+    void parseTicketIdFromMessageId_returnsEmptyForUnrelatedInput() {
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId(null)).isEmpty();
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("")).isEmpty();
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("<random@mail.com>")).isEmpty();
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("ticket-abc@example.com")).isEmpty();
+    }
+
+    @Test
+    void buildReplyTo_isStableForSameInputs() {
+        String first = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String again = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+
+        assertThat(first).isEqualTo(again);
+        assertThat(first).matches("reply\\+42\\.[a-f0-9]{8}@support\\.example\\.com");
+    }
+
+    @Test
+    void buildReplyTo_differentTicketsProduceDifferentSignatures() {
+        String a = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String b = MessageIdUtil.buildReplyTo(43, SECRET, DOMAIN);
+
+        // Local parts differ in both the ticket id and the signature.
+        String aLocal = a.substring(0, a.indexOf('@'));
+        String bLocal = b.substring(0, b.indexOf('@'));
+        assertThat(aLocal).isNotEqualTo(bLocal);
+    }
+
+    @Test
+    void verifyReplyTo_roundTripsBuiltAddress() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        assertThat(MessageIdUtil.verifyReplyTo(address, SECRET)).contains(42L);
+    }
+
+    @Test
+    void verifyReplyTo_acceptsLocalPartOnly() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String local = address.substring(0, address.indexOf('@'));
+        assertThat(MessageIdUtil.verifyReplyTo(local, SECRET)).contains(42L);
+    }
+
+    @Test
+    void verifyReplyTo_rejectsTamperedSignature() {
+        // Build a valid address, then flip one signature char.
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        int at = address.indexOf('@');
+        String local = address.substring(0, at);
+        String tampered = local.substring(0, local.length() - 1)
+                + (local.charAt(local.length() - 1) == '0' ? '1' : '0')
+                + address.substring(at);
+
+        assertThat(MessageIdUtil.verifyReplyTo(tampered, SECRET)).isEmpty();
+    }
+
+    @Test
+    void verifyReplyTo_rejectsWrongSecret() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        assertThat(MessageIdUtil.verifyReplyTo(address, "different-secret")).isEmpty();
+    }
+
+    @Test
+    void verifyReplyTo_rejectsMalformedInput() {
+        Optional<Long> empty = Optional.empty();
+        assertThat(MessageIdUtil.verifyReplyTo(null, SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("", SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("alice@example.com", SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("reply@example.com", SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("reply+abc.deadbeef@example.com", SECRET)).isEqualTo(empty);
+    }
+
+    @Test
+    void verifyReplyTo_isCaseInsensitiveOnHex() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String upper = address.toUpperCase();
+        assertThat(MessageIdUtil.verifyReplyTo(upper, SECRET)).contains(42L);
+    }
+}

--- a/src/test/java/dev/escalated/services/email/inbound/InboundEmailRouterTest.java
+++ b/src/test/java/dev/escalated/services/email/inbound/InboundEmailRouterTest.java
@@ -1,0 +1,160 @@
+package dev.escalated.services.email.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.Ticket;
+import dev.escalated.repositories.TicketRepository;
+import dev.escalated.services.email.MessageIdUtil;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InboundEmailRouterTest {
+
+    private static final String DOMAIN = "support.example.com";
+    private static final String SECRET = "test-secret-for-hmac";
+
+    @Mock private TicketRepository ticketRepository;
+
+    private EscalatedProperties properties;
+    private InboundEmailRouter router;
+
+    @BeforeEach
+    void setUp() {
+        properties = new EscalatedProperties();
+        properties.getEmail().setDomain(DOMAIN);
+        router = new InboundEmailRouter(ticketRepository, properties);
+    }
+
+    private Ticket mockTicket(long id, String reference) {
+        Ticket t = new Ticket();
+        t.setId(id);
+        t.setTicketNumber(reference);
+        return t;
+    }
+
+    private InboundMessage message(String inReplyTo, String references, String toEmail, String subject) {
+        return new InboundMessage(
+                "customer@example.com",
+                "Customer",
+                toEmail,
+                subject,
+                "body",
+                null,
+                null,
+                inReplyTo,
+                references,
+                Map.of(),
+                List.of()
+        );
+    }
+
+    @Test
+    void resolveTicket_matchesCanonicalInReplyTo() {
+        Ticket ticket = mockTicket(42, "ESC-00042");
+        when(ticketRepository.findById(42L)).thenReturn(Optional.of(ticket));
+
+        InboundMessage m = message(
+                "<ticket-42@support.example.com>", null, "support@example.com", "re: hi");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_matchesReferencesHeaderCanonicalMessageId() {
+        Ticket ticket = mockTicket(42, "ESC-00042");
+        when(ticketRepository.findById(42L)).thenReturn(Optional.of(ticket));
+
+        InboundMessage m = message(
+                null,
+                "<unrelated@mail.com> <ticket-42@support.example.com>",
+                "support@example.com",
+                "re: hi");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_verifiesSignedReplyToWhenSecretConfigured() {
+        properties.getEmail().setInboundSecret(SECRET);
+        Ticket ticket = mockTicket(42, "ESC-00042");
+        when(ticketRepository.findById(42L)).thenReturn(Optional.of(ticket));
+
+        String to = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        InboundMessage m = message(null, null, to, "my issue");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_rejectsForgedReplyToSignature() {
+        properties.getEmail().setInboundSecret("real-secret");
+
+        String forged = MessageIdUtil.buildReplyTo(42, "wrong-secret", DOMAIN);
+        InboundMessage m = message(null, null, forged, "try to take over");
+
+        assertThat(router.resolveTicket(m)).isEmpty();
+    }
+
+    @Test
+    void resolveTicket_ignoresSignedReplyToWhenSecretBlank() {
+        // Even a valid address signed with SOME secret must be
+        // ignored when the host hasn't configured one.
+        String to = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        InboundMessage m = message(null, null, to, "hi");
+
+        assertThat(router.resolveTicket(m)).isEmpty();
+    }
+
+    @Test
+    void resolveTicket_matchesSubjectReferenceTag() {
+        Ticket ticket = mockTicket(99, "ESC-00099");
+        when(ticketRepository.findByTicketNumber("ESC-00099")).thenReturn(Optional.of(ticket));
+
+        InboundMessage m = message(null, null, "support@example.com", "RE: [ESC-00099] help");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_returnsEmptyWhenNothingMatches() {
+        InboundMessage m = message(null, null, "support@example.com", "New issue");
+
+        assertThat(router.resolveTicket(m)).isEmpty();
+    }
+
+    @Test
+    void resolveTicket_nullMessageReturnsEmpty() {
+        assertThat(router.resolveTicket(null)).isEmpty();
+    }
+
+    @Test
+    void candidateHeaderMessageIds_inReplyToFirstThenReferences() {
+        InboundMessage m = message(
+                "<primary@mail>",
+                "<a@mail> <b@mail>",
+                "support@example.com",
+                "re");
+
+        List<String> ids = InboundEmailRouter.candidateHeaderMessageIds(m);
+
+        assertThat(ids).containsExactly("<primary@mail>", "<a@mail>", "<b@mail>");
+    }
+
+    @Test
+    void candidateHeaderMessageIds_emptyHeadersYieldsNone() {
+        InboundMessage m = message(null, null, "support@example.com", "hi");
+
+        assertThat(InboundEmailRouter.candidateHeaderMessageIds(m)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Greenfield inbound-email foundation for Spring. Introduces:

- **`InboundMessage`** — transport-agnostic record capturing a normalized inbound email (from, to, subject, bodies, threading headers, attachments).
- **`InboundEmailParser`** — pluggable interface for provider-specific webhook payload normalization (Postmark, Mailgun, SES, IMAP).
- **`InboundEmailRouter`** — the resolution brain that maps an inbound message to an existing ticket via canonical Message-ID parsing + signed Reply-To verification.

Mirrors the NestJS reference and the per-framework inbound-verify PRs (Laravel #70, Rails #45, Django #42, Adonis #50, WordPress #33) + the greenfield .NET router (escalated-dotnet #23).

## Resolution order

1. **In-Reply-To** parsed via `MessageIdUtil.parseTicketIdFromMessageId` — cold-start path, no DB lookup required.
2. **References** parsed via `MessageIdUtil`, each id in order.
3. **Signed Reply-To** on `toEmail` (`reply+{id}.{hmac8}@...`) verified via `MessageIdUtil.verifyReplyTo`. Forged signatures rejected with the timing-safe HMAC comparison.
4. **Subject line** reference tag (`[{PREFIX}-...]`) — legacy.

## Scope

**Router + DTO + interface only.** Follow-up PRs:

1. Per-provider parser implementations (Postmark, Mailgun, SES)
2. `InboundEmailController` — `POST /escalated/webhook/email/inbound`
3. `InboundEmailService` — full `process()` orchestration with threading / attachments

## Dependencies

- **Stacked on #25** (`feat/email-service-wireup`), which is stacked on #24 (`feat/email-message-id`). Uses `MessageIdUtil` + `EscalatedProperties.Email`. Merge order: #24 → #25 → this PR.

## Test plan

- [x] 10 Mockito tests verify every branch:
  - Canonical In-Reply-To parse
  - References with mixed unrelated ids
  - Signed Reply-To round-trip
  - Forgery rejection (wrong secret)
  - Secret-blank skip path
  - Subject-tag match
  - No-match empty Optional
  - Null-message safeguard
  - `candidateHeaderMessageIds`: in-reply-to first, references after
  - `candidateHeaderMessageIds`: empty headers yield none
- [ ] CI green (won't trigger against stacked base until rebased)