### PR TITLE
feat(inbound): MailgunInboundParser

### DIFF
--- a/src/main/java/dev/escalated/controllers/InboundEmailController.java
+++ b/src/main/java/dev/escalated/controllers/InboundEmailController.java
@@ -1,0 +1,121 @@
+package dev.escalated.controllers;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.Ticket;
+import dev.escalated.services.email.inbound.InboundEmailParser;
+import dev.escalated.services.email.inbound.InboundEmailRouter;
+import dev.escalated.services.email.inbound.InboundMessage;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Single ingress point for inbound-email webhooks. Dispatches the
+ * raw payload to the matching {@link InboundEmailParser} (selected
+ * via the {@code ?adapter=...} query parameter or
+ * {@code X-Escalated-Adapter} header), then resolves the parsed
+ * message to a ticket via {@link InboundEmailRouter}.
+ *
+ * <p>Guarded by a constant-time shared-secret check on the
+ * {@code X-Escalated-Inbound-Secret} header — hosts configure this
+ * via {@code escalated.email.inbound-secret} (reused for signed
+ * Reply-To verification, so the key pair is symmetric).
+ *
+ * <p>Returns JSON payloads — {@code 200 OK} on successful routing,
+ * {@code 401 Unauthorized} on secret mismatch, {@code 400 Bad Request}
+ * for unknown adapters or malformed payloads.
+ */
+@RestController
+@RequestMapping("/escalated/webhook/email")
+public class InboundEmailController {
+
+    private static final Logger log = LoggerFactory.getLogger(InboundEmailController.class);
+
+    private final EscalatedProperties properties;
+    private final InboundEmailRouter router;
+    private final Map<String, InboundEmailParser> parsersByName;
+
+    public InboundEmailController(
+            EscalatedProperties properties,
+            InboundEmailRouter router,
+            List<InboundEmailParser> parsers) {
+        this.properties = properties;
+        this.router = router;
+        Map<String, InboundEmailParser> byName = new HashMap<>();
+        for (InboundEmailParser p : parsers) {
+            byName.put(p.name().toLowerCase(), p);
+        }
+        this.parsersByName = byName;
+    }
+
+    @PostMapping("/inbound")
+    public ResponseEntity<Map<String, Object>> inbound(
+            @RequestBody Map<String, Object> payload,
+            @RequestParam(value = "adapter", required = false) String adapterQuery,
+            @RequestHeader(value = "X-Escalated-Adapter", required = false) String adapterHeader,
+            @RequestHeader(value = "X-Escalated-Inbound-Secret", required = false) String providedSecret) {
+
+        if (!verifySecret(providedSecret)) {
+            return ResponseEntity.status(401).body(Map.of("error", "missing or invalid inbound secret"));
+        }
+
+        String adapter = firstNonEmpty(adapterQuery, adapterHeader);
+        if (adapter == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "missing adapter"));
+        }
+        InboundEmailParser parser = parsersByName.get(adapter.toLowerCase());
+        if (parser == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "unknown adapter: " + adapter));
+        }
+
+        InboundMessage message;
+        try {
+            message = parser.parse(payload);
+        } catch (RuntimeException ex) {
+            log.warn("[InboundEmailController] parse failed for {}: {}", adapter, ex.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid payload"));
+        }
+
+        Optional<Ticket> resolved = router.resolveTicket(message);
+        String status = resolved.isPresent() ? "matched" : "unmatched";
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", status);
+        response.put("ticketId", resolved.map(Ticket::getId).orElse(null));
+        return ResponseEntity.accepted().body(response);
+    }
+
+    private boolean verifySecret(String provided) {
+        String expected = properties.getEmail() == null
+                ? ""
+                : (properties.getEmail().getInboundSecret() == null ? "" : properties.getEmail().getInboundSecret());
+        if (expected.isEmpty() || provided == null) {
+            // Inbound signing not configured → effectively disables
+            // the webhook (prevents accidental unauthenticated routing).
+            return false;
+        }
+        byte[] e = expected.getBytes(StandardCharsets.UTF_8);
+        byte[] p = provided.getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(e, p);
+    }
+
+    private static String firstNonEmpty(String... values) {
+        for (String v : values) {
+            if (v != null && !v.isEmpty()) {
+                return v;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundAttachment.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundAttachment.java
@@ -1,0 +1,15 @@
+package dev.escalated.services.email.inbound;
+
+/**
+ * Inbound attachment. Providers either inline the content (small
+ * attachments) or supply a URL to download it from (larger
+ * provider-hosted attachments).
+ */
+public record InboundAttachment(
+        String name,
+        String contentType,
+        Long sizeBytes,
+        byte[] content,
+        String downloadUrl
+) {
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundEmailParser.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundEmailParser.java
@@ -1,0 +1,27 @@
+package dev.escalated.services.email.inbound;
+
+/**
+ * Transport-specific parser that normalizes a provider's webhook
+ * payload into an {@link InboundMessage}. Implementations register
+ * themselves as Spring beans and are resolved by {@link #name()}
+ * (matches the adapter label on the inbound webhook request).
+ *
+ * <p>Add a new provider by implementing this interface; the inbound
+ * controller will pick it up via DI when the request's adapter label
+ * matches {@link #name()}.
+ */
+public interface InboundEmailParser {
+
+    /**
+     * Short provider name. Must match the value in the
+     * {@code ?adapter=...} query parameter or the
+     * {@code X-Escalated-Adapter} header on the inbound webhook.
+     */
+    String name();
+
+    /**
+     * Parse a raw webhook payload (e.g. a provider-specific JSON
+     * object) into an {@link InboundMessage}.
+     */
+    InboundMessage parse(Object rawPayload);
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundEmailRouter.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundEmailRouter.java
@@ -1,0 +1,125 @@
+package dev.escalated.services.email.inbound;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.Ticket;
+import dev.escalated.repositories.TicketRepository;
+import dev.escalated.services.email.MessageIdUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves an inbound email to an existing ticket via canonical
+ * Message-ID parsing + signed Reply-To verification.
+ *
+ * <p>Resolution order (first match wins):
+ * <ol>
+ *   <li>{@code In-Reply-To} parsed via {@link MessageIdUtil#parseTicketIdFromMessageId}
+ *       — cold-start path, no DB lookup on the header value required
+ *       (we know our own Message-ID format).</li>
+ *   <li>{@code References} parsed via {@link MessageIdUtil#parseTicketIdFromMessageId},
+ *       each id in order.</li>
+ *   <li>Signed Reply-To on {@link InboundMessage#toEmail()}
+ *       ({@code reply+{id}.{hmac8}@...}) verified via
+ *       {@link MessageIdUtil#verifyReplyTo}. Survives clients that
+ *       strip our threading headers; forged signatures are rejected
+ *       with a timing-safe HMAC comparison.</li>
+ *   <li>Subject line reference tag (e.g. {@code [ESC-00001]}) — legacy.</li>
+ *   <li>Audit-log lookup — not implemented in this PR; the row is
+ *       inserted by the inbound controller once the service lands.</li>
+ * </ol>
+ *
+ * <p>Mirrors the NestJS {@code InboundRouterService} resolution order
+ * and the Laravel/Rails/Django/Adonis/WordPress/.NET ports.
+ */
+@Service
+public class InboundEmailRouter {
+
+    private static final Logger log = LoggerFactory.getLogger(InboundEmailRouter.class);
+
+    private final TicketRepository ticketRepository;
+    private final EscalatedProperties properties;
+
+    public InboundEmailRouter(TicketRepository ticketRepository, EscalatedProperties properties) {
+        this.ticketRepository = ticketRepository;
+        this.properties = properties;
+    }
+
+    /**
+     * Resolve the inbound email to an existing ticket, or
+     * {@link Optional#empty()} when no match (caller should create a
+     * new ticket).
+     */
+    public Optional<Ticket> resolveTicket(InboundMessage message) {
+        if (message == null) {
+            return Optional.empty();
+        }
+
+        List<String> headerIds = candidateHeaderMessageIds(message);
+
+        // 1 + 2. Parse canonical Message-IDs out of our own headers.
+        for (String raw : headerIds) {
+            Optional<Long> ticketId = MessageIdUtil.parseTicketIdFromMessageId(raw);
+            if (ticketId.isPresent()) {
+                Optional<Ticket> ticket = ticketRepository.findById(ticketId.get());
+                if (ticket.isPresent()) {
+                    return ticket;
+                }
+            }
+        }
+
+        // 3. Signed Reply-To on the recipient address.
+        String secret = properties.getEmail() == null ? null : properties.getEmail().getInboundSecret();
+        if (secret != null && !secret.isBlank() && message.toEmail() != null) {
+            Optional<Long> verified = MessageIdUtil.verifyReplyTo(message.toEmail(), secret);
+            if (verified.isPresent()) {
+                Optional<Ticket> ticket = ticketRepository.findById(verified.get());
+                if (ticket.isPresent()) {
+                    return ticket;
+                }
+                log.debug("[InboundEmailRouter] Reply-To verified but ticket #{} not found", verified.get());
+            }
+        }
+
+        // 4. Subject line reference tag.
+        if (message.subject() != null) {
+            Matcher m = SUBJECT_REF_PATTERN.matcher(message.subject());
+            if (m.find()) {
+                // Ticket reference is stored in the ticket_number column.
+                Optional<Ticket> ticket = ticketRepository.findByTicketNumber(m.group(1));
+                if (ticket.isPresent()) {
+                    return ticket;
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Return every candidate Message-ID from the inbound headers in
+     * the order the mail client sent them. Caller iterates the
+     * result and stops at the first resolvable id.
+     */
+    public static List<String> candidateHeaderMessageIds(InboundMessage message) {
+        List<String> ids = new ArrayList<>();
+        if (message.inReplyTo() != null && !message.inReplyTo().isBlank()) {
+            ids.add(message.inReplyTo().trim());
+        }
+        if (message.references() != null && !message.references().isBlank()) {
+            for (String raw : message.references().trim().split("\\s+")) {
+                if (!raw.isBlank()) {
+                    ids.add(raw);
+                }
+            }
+        }
+        return ids;
+    }
+
+    private static final Pattern SUBJECT_REF_PATTERN = Pattern.compile("\\[([A-Z]+-[0-9A-Z-]+)\\]");
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundMessage.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundMessage.java
@@ -1,0 +1,45 @@
+package dev.escalated.services.email.inbound;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Transport-agnostic representation of an inbound email, independent
+ * of the source adapter (Postmark, Mailgun, SES, IMAP, etc.).
+ *
+ * <p>Adapters normalize their webhook payload into this shape; the
+ * {@link InboundEmailRouter} then resolves it to a ticket by parsing
+ * canonical Message-IDs out of {@code inReplyTo} / {@code references}
+ * and verifying the signed Reply-To on {@code toEmail}.
+ *
+ * <p>Mirrors the NestJS reference and the per-framework ports.
+ */
+public record InboundMessage(
+        String fromEmail,
+        String fromName,
+        String toEmail,
+        String subject,
+        String bodyText,
+        String bodyHtml,
+        String messageId,
+        String inReplyTo,
+        String references,
+        Map<String, String> headers,
+        List<InboundAttachment> attachments
+) {
+
+    public InboundMessage {
+        headers = headers == null ? Map.of() : headers;
+        attachments = attachments == null ? List.of() : attachments;
+    }
+
+    /**
+     * Best body content (plain text preferred, HTML fallback).
+     */
+    public String body() {
+        if (bodyText != null && !bodyText.isEmpty()) {
+            return bodyText;
+        }
+        return bodyHtml != null ? bodyHtml : "";
+    }
+}

--- a/src/main/java/dev/escalated/services/email/inbound/MailgunInboundParser.java
+++ b/src/main/java/dev/escalated/services/email/inbound/MailgunInboundParser.java
@@ -1,0 +1,135 @@
+package dev.escalated.services.email.inbound;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses Mailgun's inbound webhook payload into an
+ * {@link InboundMessage}. Mailgun POSTs {@code multipart/form-data}
+ * with snake-case field names: {@code sender}, {@code recipient},
+ * {@code subject}, {@code body-plain}, {@code body-html},
+ * {@code Message-Id}, {@code In-Reply-To}, {@code References}, plus
+ * a JSON-encoded {@code attachments} field.
+ *
+ * <p>The Spring controller already ingests a
+ * {@code Map<String,Object>} from the webhook body, so this parser
+ * just reads from that map.
+ *
+ * <p>Mailgun hosts attachment content behind provider URLs (for
+ * large attachments); we carry the URL through in
+ * {@link InboundAttachment#downloadUrl} so a follow-up worker can
+ * fetch + persist out-of-band.
+ */
+@Component
+public class MailgunInboundParser implements InboundEmailParser {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String name() {
+        return "mailgun";
+    }
+
+    @Override
+    public InboundMessage parse(Object rawPayload) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = rawPayload instanceof Map<?, ?> m
+                ? (Map<String, Object>) m
+                : MAPPER.convertValue(rawPayload, new TypeReference<Map<String, Object>>() {});
+
+        String fromEmail = stringAt(payload, "sender");
+        if (fromEmail == null || fromEmail.isEmpty()) {
+            fromEmail = stringAt(payload, "from");
+        }
+        String fromName = extractFromName(stringAt(payload, "from"));
+
+        String toEmail = stringAt(payload, "recipient");
+        if (toEmail == null || toEmail.isEmpty()) {
+            toEmail = stringAt(payload, "To");
+        }
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        putIfNonEmpty(headers, "Message-ID", stringAt(payload, "Message-Id"));
+        putIfNonEmpty(headers, "In-Reply-To", stringAt(payload, "In-Reply-To"));
+        putIfNonEmpty(headers, "References", stringAt(payload, "References"));
+
+        return new InboundMessage(
+                fromEmail == null ? "" : fromEmail,
+                fromName,
+                toEmail == null ? "" : toEmail,
+                stringAt(payload, "subject"),
+                stringAt(payload, "body-plain"),
+                stringAt(payload, "body-html"),
+                stringAt(payload, "Message-Id"),
+                stringAt(payload, "In-Reply-To"),
+                stringAt(payload, "References"),
+                headers,
+                extractAttachments(stringAt(payload, "attachments"))
+        );
+    }
+
+    private static String stringAt(Map<String, Object> payload, String key) {
+        Object v = payload.get(key);
+        return v == null ? null : v.toString();
+    }
+
+    private static void putIfNonEmpty(Map<String, String> headers, String key, String value) {
+        if (value != null && !value.isEmpty()) {
+            headers.put(key, value);
+        }
+    }
+
+    /**
+     * Mailgun's {@code from} field is typically
+     * {@code "Full Name <email@host>"} — extract the display name
+     * portion. Returns {@code null} when the input has no angle-
+     * bracketed email (bare email address).
+     */
+    private static String extractFromName(String raw) {
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        int angle = raw.indexOf('<');
+        if (angle <= 0) {
+            return null;
+        }
+        String name = raw.substring(0, angle).trim();
+        // Strip surrounding quotes if present.
+        if (name.length() >= 2 && name.startsWith("\"") && name.endsWith("\"")) {
+            name = name.substring(1, name.length() - 1);
+        }
+        return name.isEmpty() ? null : name;
+    }
+
+    private static List<InboundAttachment> extractAttachments(String attachmentsJson) {
+        if (attachmentsJson == null || attachmentsJson.isEmpty()) {
+            return new ArrayList<>();
+        }
+        try {
+            List<Map<String, Object>> entries = MAPPER.readValue(
+                    attachmentsJson, new TypeReference<List<Map<String, Object>>>() {});
+            List<InboundAttachment> list = new ArrayList<>();
+            for (Map<String, Object> entry : entries) {
+                String name = stringAt(entry, "name");
+                String contentType = stringAt(entry, "content-type");
+                Long size = entry.get("size") instanceof Number n ? n.longValue() : null;
+                String url = stringAt(entry, "url");
+                list.add(new InboundAttachment(
+                        name == null ? "attachment" : name,
+                        contentType == null ? "application/octet-stream" : contentType,
+                        size,
+                        null,
+                        url
+                ));
+            }
+            return list;
+        } catch (Exception ex) {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/dev/escalated/services/email/inbound/PostmarkInboundParser.java
+++ b/src/main/java/dev/escalated/services/email/inbound/PostmarkInboundParser.java
@@ -1,0 +1,125 @@
+package dev.escalated.services.email.inbound;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses Postmark's inbound webhook payload into an
+ * {@link InboundMessage}. Postmark POSTs a JSON body with
+ * {@code FromFull} / {@code ToFull} / {@code Subject} / {@code TextBody}
+ * / {@code HtmlBody} / {@code Headers} / {@code Attachments} fields.
+ *
+ * <p>Register additional providers (Mailgun, SES) by implementing
+ * {@link InboundEmailParser} as Spring {@code @Component}s — the
+ * controller selects by {@link #name()}.
+ */
+@Component
+public class PostmarkInboundParser implements InboundEmailParser {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String name() {
+        return "postmark";
+    }
+
+    @Override
+    public InboundMessage parse(Object rawPayload) {
+        JsonNode root = MAPPER.valueToTree(rawPayload);
+
+        JsonNode fromFull = root.path("FromFull");
+        String fromEmail = fromFull.path("Email").asText(root.path("From").asText(""));
+        String fromName = fromFull.path("Name").asText(null);
+
+        String toEmail = root.path("OriginalRecipient").asText(null);
+        if (toEmail == null || toEmail.isEmpty()) {
+            toEmail = firstToEmail(root);
+        }
+        if (toEmail == null || toEmail.isEmpty()) {
+            toEmail = root.path("To").asText("");
+        }
+
+        Map<String, String> headers = extractHeaders(root);
+
+        return new InboundMessage(
+                fromEmail,
+                fromName,
+                toEmail,
+                root.path("Subject").asText(""),
+                textOrNull(root, "TextBody"),
+                textOrNull(root, "HtmlBody"),
+                firstNonEmpty(textOrNull(root, "MessageID"), headers.get("Message-ID")),
+                headers.get("In-Reply-To"),
+                headers.get("References"),
+                headers,
+                extractAttachments(root)
+        );
+    }
+
+    private static String firstToEmail(JsonNode root) {
+        JsonNode toFull = root.path("ToFull");
+        if (!toFull.isArray()) {
+            return null;
+        }
+        for (JsonNode entry : toFull) {
+            String email = entry.path("Email").asText(null);
+            if (email != null && !email.isEmpty()) {
+                return email;
+            }
+        }
+        return null;
+    }
+
+    private static Map<String, String> extractHeaders(JsonNode root) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        JsonNode arr = root.path("Headers");
+        if (!arr.isArray()) {
+            return headers;
+        }
+        for (JsonNode entry : arr) {
+            String name = entry.path("Name").asText(null);
+            String value = entry.path("Value").asText(null);
+            if (name != null && !name.isEmpty() && value != null) {
+                headers.put(name, value);
+            }
+        }
+        return headers;
+    }
+
+    private static List<InboundAttachment> extractAttachments(JsonNode root) {
+        List<InboundAttachment> list = new ArrayList<>();
+        JsonNode arr = root.path("Attachments");
+        if (!arr.isArray()) {
+            return list;
+        }
+        for (JsonNode entry : arr) {
+            String name = entry.path("Name").asText("attachment");
+            String contentType = entry.path("ContentType").asText("application/octet-stream");
+            Long size = entry.has("ContentLength") ? entry.path("ContentLength").asLong() : null;
+            String contentBase64 = textOrNull(entry, "Content");
+            byte[] content = contentBase64 != null ? Base64.getDecoder().decode(contentBase64) : null;
+            list.add(new InboundAttachment(name, contentType, size, content, null));
+        }
+        return list;
+    }
+
+    private static String textOrNull(JsonNode parent, String field) {
+        JsonNode node = parent.path(field);
+        return node.isMissingNode() || node.isNull() ? null : node.asText(null);
+    }
+
+    private static String firstNonEmpty(String... values) {
+        for (String v : values) {
+            if (v != null && !v.isEmpty()) {
+                return v;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/dev/escalated/services/email/inbound/InboundEmailRouterTest.java
+++ b/src/test/java/dev/escalated/services/email/inbound/InboundEmailRouterTest.java
@@ -1,0 +1,160 @@
+package dev.escalated.services.email.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.Ticket;
+import dev.escalated.repositories.TicketRepository;
+import dev.escalated.services.email.MessageIdUtil;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InboundEmailRouterTest {
+
+    private static final String DOMAIN = "support.example.com";
+    private static final String SECRET = "test-secret-for-hmac";
+
+    @Mock private TicketRepository ticketRepository;
+
+    private EscalatedProperties properties;
+    private InboundEmailRouter router;
+
+    @BeforeEach
+    void setUp() {
+        properties = new EscalatedProperties();
+        properties.getEmail().setDomain(DOMAIN);
+        router = new InboundEmailRouter(ticketRepository, properties);
+    }
+
+    private Ticket mockTicket(long id, String reference) {
+        Ticket t = new Ticket();
+        t.setId(id);
+        t.setTicketNumber(reference);
+        return t;
+    }
+
+    private InboundMessage message(String inReplyTo, String references, String toEmail, String subject) {
+        return new InboundMessage(
+                "customer@example.com",
+                "Customer",
+                toEmail,
+                subject,
+                "body",
+                null,
+                null,
+                inReplyTo,
+                references,
+                Map.of(),
+                List.of()
+        );
+    }
+
+    @Test
+    void resolveTicket_matchesCanonicalInReplyTo() {
+        Ticket ticket = mockTicket(42, "ESC-00042");
+        when(ticketRepository.findById(42L)).thenReturn(Optional.of(ticket));
+
+        InboundMessage m = message(
+                "<ticket-42@support.example.com>", null, "support@example.com", "re: hi");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_matchesReferencesHeaderCanonicalMessageId() {
+        Ticket ticket = mockTicket(42, "ESC-00042");
+        when(ticketRepository.findById(42L)).thenReturn(Optional.of(ticket));
+
+        InboundMessage m = message(
+                null,
+                "<unrelated@mail.com> <ticket-42@support.example.com>",
+                "support@example.com",
+                "re: hi");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_verifiesSignedReplyToWhenSecretConfigured() {
+        properties.getEmail().setInboundSecret(SECRET);
+        Ticket ticket = mockTicket(42, "ESC-00042");
+        when(ticketRepository.findById(42L)).thenReturn(Optional.of(ticket));
+
+        String to = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        InboundMessage m = message(null, null, to, "my issue");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_rejectsForgedReplyToSignature() {
+        properties.getEmail().setInboundSecret("real-secret");
+
+        String forged = MessageIdUtil.buildReplyTo(42, "wrong-secret", DOMAIN);
+        InboundMessage m = message(null, null, forged, "try to take over");
+
+        assertThat(router.resolveTicket(m)).isEmpty();
+    }
+
+    @Test
+    void resolveTicket_ignoresSignedReplyToWhenSecretBlank() {
+        // Even a valid address signed with SOME secret must be
+        // ignored when the host hasn't configured one.
+        String to = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        InboundMessage m = message(null, null, to, "hi");
+
+        assertThat(router.resolveTicket(m)).isEmpty();
+    }
+
+    @Test
+    void resolveTicket_matchesSubjectReferenceTag() {
+        Ticket ticket = mockTicket(99, "ESC-00099");
+        when(ticketRepository.findByTicketNumber("ESC-00099")).thenReturn(Optional.of(ticket));
+
+        InboundMessage m = message(null, null, "support@example.com", "RE: [ESC-00099] help");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_returnsEmptyWhenNothingMatches() {
+        InboundMessage m = message(null, null, "support@example.com", "New issue");
+
+        assertThat(router.resolveTicket(m)).isEmpty();
+    }
+
+    @Test
+    void resolveTicket_nullMessageReturnsEmpty() {
+        assertThat(router.resolveTicket(null)).isEmpty();
+    }
+
+    @Test
+    void candidateHeaderMessageIds_inReplyToFirstThenReferences() {
+        InboundMessage m = message(
+                "<primary@mail>",
+                "<a@mail> <b@mail>",
+                "support@example.com",
+                "re");
+
+        List<String> ids = InboundEmailRouter.candidateHeaderMessageIds(m);
+
+        assertThat(ids).containsExactly("<primary@mail>", "<a@mail>", "<b@mail>");
+    }
+
+    @Test
+    void candidateHeaderMessageIds_emptyHeadersYieldsNone() {
+        InboundMessage m = message(null, null, "support@example.com", "hi");
+
+        assertThat(InboundEmailRouter.candidateHeaderMessageIds(m)).isEmpty();
+    }
+}

--- a/src/test/java/dev/escalated/services/email/inbound/MailgunInboundParserTest.java
+++ b/src/test/java/dev/escalated/services/email/inbound/MailgunInboundParserTest.java
@@ -1,0 +1,114 @@
+package dev.escalated.services.email.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MailgunInboundParserTest {
+
+    private Map<String, Object> sampleFormData() {
+        Map<String, Object> m = new HashMap<>();
+        m.put("sender", "customer@example.com");
+        m.put("from", "Customer <customer@example.com>");
+        m.put("recipient", "support+abc@support.example.com");
+        m.put("To", "support+abc@support.example.com");
+        m.put("subject", "[ESC-00042] Help");
+        m.put("body-plain", "Plain body");
+        m.put("body-html", "<p>HTML body</p>");
+        m.put("Message-Id", "<mailgun-incoming@mail.client>");
+        m.put("In-Reply-To", "<ticket-42@support.example.com>");
+        m.put("References", "<ticket-42@support.example.com>");
+        m.put("attachments",
+                "[{\"name\":\"report.pdf\",\"content-type\":\"application/pdf\",\"size\":5120,\"url\":\"https://mailgun.example/att/abc\"}]");
+        return m;
+    }
+
+    @Test
+    void nameIsMailgun() {
+        assertThat(new MailgunInboundParser().name()).isEqualTo("mailgun");
+    }
+
+    @Test
+    void parseExtractsCoreFields() {
+        InboundMessage m = new MailgunInboundParser().parse(sampleFormData());
+
+        assertThat(m.fromEmail()).isEqualTo("customer@example.com");
+        assertThat(m.fromName()).isEqualTo("Customer");
+        assertThat(m.toEmail()).isEqualTo("support+abc@support.example.com");
+        assertThat(m.subject()).isEqualTo("[ESC-00042] Help");
+        assertThat(m.bodyText()).isEqualTo("Plain body");
+        assertThat(m.bodyHtml()).isEqualTo("<p>HTML body</p>");
+    }
+
+    @Test
+    void parseExtractsThreadingHeaders() {
+        InboundMessage m = new MailgunInboundParser().parse(sampleFormData());
+
+        assertThat(m.inReplyTo()).isEqualTo("<ticket-42@support.example.com>");
+        assertThat(m.references()).isEqualTo("<ticket-42@support.example.com>");
+    }
+
+    @Test
+    void parseProviderHostedAttachments() {
+        InboundMessage m = new MailgunInboundParser().parse(sampleFormData());
+
+        assertThat(m.attachments()).hasSize(1);
+        InboundAttachment a = m.attachments().get(0);
+        assertThat(a.name()).isEqualTo("report.pdf");
+        assertThat(a.contentType()).isEqualTo("application/pdf");
+        assertThat(a.sizeBytes()).isEqualTo(5120L);
+        assertThat(a.downloadUrl()).isEqualTo("https://mailgun.example/att/abc");
+        // Mailgun hosts content — no inline bytes.
+        assertThat(a.content()).isNull();
+    }
+
+    @Test
+    void parseHandlesMalformedAttachmentsJson() {
+        Map<String, Object> data = sampleFormData();
+        data.put("attachments", "not json");
+
+        InboundMessage m = new MailgunInboundParser().parse(data);
+
+        assertThat(m.attachments()).isEmpty();
+    }
+
+    @Test
+    void parseFallsBackSenderToFromOnMissing() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("from", "only-from@example.com");
+        data.put("recipient", "support@example.com");
+        data.put("subject", "hi");
+
+        InboundMessage m = new MailgunInboundParser().parse(data);
+
+        assertThat(m.fromEmail()).isEqualTo("only-from@example.com");
+    }
+
+    @Test
+    void parseExtractFromNameReturnsNullWithoutAngleBrackets() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("sender", "bareemail@example.com");
+        data.put("from", "bareemail@example.com");
+        data.put("recipient", "support@example.com");
+        data.put("subject", "hi");
+
+        InboundMessage m = new MailgunInboundParser().parse(data);
+
+        assertThat(m.fromName()).isNull();
+    }
+
+    @Test
+    void parseStripsQuotesFromFromName() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("sender", "jane@example.com");
+        data.put("from", "\"Jane Doe\" <jane@example.com>");
+        data.put("recipient", "support@example.com");
+        data.put("subject", "hi");
+
+        InboundMessage m = new MailgunInboundParser().parse(data);
+
+        assertThat(m.fromName()).isEqualTo("Jane Doe");
+    }
+}

--- a/src/test/java/dev/escalated/services/email/inbound/PostmarkInboundParserTest.java
+++ b/src/test/java/dev/escalated/services/email/inbound/PostmarkInboundParserTest.java
@@ -1,0 +1,105 @@
+package dev.escalated.services.email.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PostmarkInboundParserTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String SAMPLE_PAYLOAD = """
+        {
+          "FromName": "Customer",
+          "MessageID": "22c74902-a0c1-4511-804f2-341342852c90",
+          "FromFull": {"Email": "customer@example.com", "Name": "Customer"},
+          "To": "support+abc@support.example.com",
+          "ToFull": [{"Email": "support+abc@support.example.com", "Name": ""}],
+          "OriginalRecipient": "support+abc@support.example.com",
+          "Subject": "[ESC-00042] Help",
+          "TextBody": "Plain body",
+          "HtmlBody": "<p>HTML body</p>",
+          "Headers": [
+            {"Name": "Message-ID", "Value": "<abc@mail.client>"},
+            {"Name": "In-Reply-To", "Value": "<ticket-42@support.example.com>"},
+            {"Name": "References", "Value": "<ticket-42@support.example.com>"}
+          ],
+          "Attachments": [
+            {"Name": "report.pdf", "Content": "aGVsbG8=",
+             "ContentType": "application/pdf", "ContentLength": 5}
+          ]
+        }
+        """;
+
+    private static Map<String, Object> parsePayload(String json) throws Exception {
+        return MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+    }
+
+    @Test
+    void parse_extractsCoreFields() throws Exception {
+        PostmarkInboundParser parser = new PostmarkInboundParser();
+
+        InboundMessage m = parser.parse(parsePayload(SAMPLE_PAYLOAD));
+
+        assertThat(m.fromEmail()).isEqualTo("customer@example.com");
+        assertThat(m.fromName()).isEqualTo("Customer");
+        assertThat(m.toEmail()).isEqualTo("support+abc@support.example.com");
+        assertThat(m.subject()).isEqualTo("[ESC-00042] Help");
+        assertThat(m.bodyText()).isEqualTo("Plain body");
+        assertThat(m.bodyHtml()).isEqualTo("<p>HTML body</p>");
+    }
+
+    @Test
+    void parse_extractsThreadingHeaders() throws Exception {
+        PostmarkInboundParser parser = new PostmarkInboundParser();
+
+        InboundMessage m = parser.parse(parsePayload(SAMPLE_PAYLOAD));
+
+        assertThat(m.inReplyTo()).isEqualTo("<ticket-42@support.example.com>");
+        assertThat(m.references()).isEqualTo("<ticket-42@support.example.com>");
+    }
+
+    @Test
+    void parse_extractsAttachments() throws Exception {
+        PostmarkInboundParser parser = new PostmarkInboundParser();
+
+        InboundMessage m = parser.parse(parsePayload(SAMPLE_PAYLOAD));
+
+        assertThat(m.attachments()).hasSize(1);
+        InboundAttachment a = m.attachments().get(0);
+        assertThat(a.name()).isEqualTo("report.pdf");
+        assertThat(a.contentType()).isEqualTo("application/pdf");
+        assertThat(a.sizeBytes()).isEqualTo(5L);
+        assertThat(new String(a.content())).isEqualTo("hello");
+    }
+
+    @Test
+    void parse_handlesMinimalPayload() throws Exception {
+        String json = """
+            {
+              "FromFull": {"Email": "a@b.com"},
+              "ToFull": [{"Email": "c@d.com"}],
+              "Subject": "minimal"
+            }
+            """;
+        PostmarkInboundParser parser = new PostmarkInboundParser();
+
+        InboundMessage m = parser.parse(parsePayload(json));
+
+        assertThat(m.fromEmail()).isEqualTo("a@b.com");
+        assertThat(m.fromName()).isNull();
+        assertThat(m.toEmail()).isEqualTo("c@d.com");
+        assertThat(m.subject()).isEqualTo("minimal");
+        assertThat(m.bodyText()).isNull();
+        assertThat(m.inReplyTo()).isNull();
+        assertThat(m.attachments()).isEmpty();
+    }
+
+    @Test
+    void name_isPostmark() {
+        assertThat(new PostmarkInboundParser().name()).isEqualTo("postmark");
+    }
+}


### PR DESCRIPTION
## Summary

Adds Mailgun as the second supported inbound provider alongside Postmark (from #27). Mirrors the .NET counterpart (escalated-dotnet #25).

Mailgun POSTs `multipart/form-data` with snake-case field names (`sender` / `recipient` / `body-plain` / `body-html` / `Message-Id` / `In-Reply-To` / `References` / `attachments`). The Spring controller already ingests a `Map<String, Object>` from the webhook body, so this parser just reads from that map; the controller routes via `?adapter=mailgun`.

## Notes

- Mailgun's `from` is typically `"Name <email>"` — we extract the display name portion and fall back to the `sender` field for the email. Surrounding quotes on the name are stripped.
- Mailgun hosts attachment content behind a URL (large attachments). We carry the URL through in `downloadUrl`; a follow-up worker can fetch + persist out-of-band.
- Malformed attachments JSON degrades gracefully (empty list).

## Dependencies

- **Stacked on #27** (`feat/inbound-email-controller`). Merge order: #24 → #25 → #26 → #27 → this PR.

## Test plan

- [x] 7 JUnit tests cover core field extraction, threading headers, provider-hosted attachment parsing, malformed attachments JSON, sender→from fallback, bare-email (no display name) handling, and quote-stripping on display names
- [ ] CI green (won't trigger against stacked base until rebased)