### PR TITLE
feat(inbound): InboundEmailService orchestrates reply/create + wire into controller

### DIFF
--- a/src/main/java/dev/escalated/config/EscalatedProperties.java
+++ b/src/main/java/dev/escalated/config/EscalatedProperties.java
@@ -15,6 +15,7 @@ public class EscalatedProperties {
     private WebhookProperties webhook = new WebhookProperties();
     private WidgetProperties widget = new WidgetProperties();
     private GuestAccessProperties guestAccess = new GuestAccessProperties();
+    private EmailProperties email = new EmailProperties();
 
     public boolean isEnabled() {
         return enabled;
@@ -94,6 +95,14 @@ public class EscalatedProperties {
 
     public void setGuestAccess(GuestAccessProperties guestAccess) {
         this.guestAccess = guestAccess;
+    }
+
+    public EmailProperties getEmail() {
+        return email;
+    }
+
+    public void setEmail(EmailProperties email) {
+        this.email = email;
     }
 
     public static class KnowledgeBaseProperties {
@@ -189,6 +198,34 @@ public class EscalatedProperties {
 
         public void setEnabled(boolean enabled) {
             this.enabled = enabled;
+        }
+    }
+
+    /**
+     * Outbound + inbound email config. {@code domain} is used for the
+     * right-hand side of RFC 5322 Message-IDs and signed Reply-To
+     * addresses. {@code inboundSecret} is the HMAC key used to sign
+     * Reply-To addresses so the inbound provider webhook can verify
+     * a ticket id without trusting the mail client's threading headers.
+     */
+    public static class EmailProperties {
+        private String domain = "localhost";
+        private String inboundSecret = "";
+
+        public String getDomain() {
+            return domain;
+        }
+
+        public void setDomain(String domain) {
+            this.domain = domain;
+        }
+
+        public String getInboundSecret() {
+            return inboundSecret;
+        }
+
+        public void setInboundSecret(String inboundSecret) {
+            this.inboundSecret = inboundSecret;
         }
     }
 }

--- a/src/main/java/dev/escalated/controllers/InboundEmailController.java
+++ b/src/main/java/dev/escalated/controllers/InboundEmailController.java
@@ -1,16 +1,14 @@
 package dev.escalated.controllers;
 
 import dev.escalated.config.EscalatedProperties;
-import dev.escalated.models.Ticket;
 import dev.escalated.services.email.inbound.InboundEmailParser;
-import dev.escalated.services.email.inbound.InboundEmailRouter;
+import dev.escalated.services.email.inbound.InboundEmailService;
 import dev.escalated.services.email.inbound.InboundMessage;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -44,15 +42,15 @@ public class InboundEmailController {
     private static final Logger log = LoggerFactory.getLogger(InboundEmailController.class);
 
     private final EscalatedProperties properties;
-    private final InboundEmailRouter router;
+    private final InboundEmailService inboundService;
     private final Map<String, InboundEmailParser> parsersByName;
 
     public InboundEmailController(
             EscalatedProperties properties,
-            InboundEmailRouter router,
+            InboundEmailService inboundService,
             List<InboundEmailParser> parsers) {
         this.properties = properties;
-        this.router = router;
+        this.inboundService = inboundService;
         Map<String, InboundEmailParser> byName = new HashMap<>();
         for (InboundEmailParser p : parsers) {
             byName.put(p.name().toLowerCase(), p);
@@ -88,11 +86,19 @@ public class InboundEmailController {
             return ResponseEntity.badRequest().body(Map.of("error", "invalid payload"));
         }
 
-        Optional<Ticket> resolved = router.resolveTicket(message);
-        String status = resolved.isPresent() ? "matched" : "unmatched";
+        InboundEmailService.ProcessResult result;
+        try {
+            result = inboundService.process(message);
+        } catch (RuntimeException ex) {
+            log.error("[InboundEmailController] process failed: {}", ex.getMessage());
+            return ResponseEntity.status(500).body(Map.of("error", "processing failed"));
+        }
+
         Map<String, Object> response = new HashMap<>();
-        response.put("status", status);
-        response.put("ticketId", resolved.map(Ticket::getId).orElse(null));
+        response.put("outcome", result.outcome().name().toLowerCase());
+        response.put("ticketId", result.ticketId());
+        response.put("replyId", result.replyId());
+        response.put("pendingAttachmentDownloads", result.pendingAttachmentDownloads());
         return ResponseEntity.accepted().body(response);
     }
 

--- a/src/main/java/dev/escalated/controllers/InboundEmailController.java
+++ b/src/main/java/dev/escalated/controllers/InboundEmailController.java
@@ -1,0 +1,121 @@
+package dev.escalated.controllers;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.Ticket;
+import dev.escalated.services.email.inbound.InboundEmailParser;
+import dev.escalated.services.email.inbound.InboundEmailRouter;
+import dev.escalated.services.email.inbound.InboundMessage;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Single ingress point for inbound-email webhooks. Dispatches the
+ * raw payload to the matching {@link InboundEmailParser} (selected
+ * via the {@code ?adapter=...} query parameter or
+ * {@code X-Escalated-Adapter} header), then resolves the parsed
+ * message to a ticket via {@link InboundEmailRouter}.
+ *
+ * <p>Guarded by a constant-time shared-secret check on the
+ * {@code X-Escalated-Inbound-Secret} header — hosts configure this
+ * via {@code escalated.email.inbound-secret} (reused for signed
+ * Reply-To verification, so the key pair is symmetric).
+ *
+ * <p>Returns JSON payloads — {@code 200 OK} on successful routing,
+ * {@code 401 Unauthorized} on secret mismatch, {@code 400 Bad Request}
+ * for unknown adapters or malformed payloads.
+ */
+@RestController
+@RequestMapping("/escalated/webhook/email")
+public class InboundEmailController {
+
+    private static final Logger log = LoggerFactory.getLogger(InboundEmailController.class);
+
+    private final EscalatedProperties properties;
+    private final InboundEmailRouter router;
+    private final Map<String, InboundEmailParser> parsersByName;
+
+    public InboundEmailController(
+            EscalatedProperties properties,
+            InboundEmailRouter router,
+            List<InboundEmailParser> parsers) {
+        this.properties = properties;
+        this.router = router;
+        Map<String, InboundEmailParser> byName = new HashMap<>();
+        for (InboundEmailParser p : parsers) {
+            byName.put(p.name().toLowerCase(), p);
+        }
+        this.parsersByName = byName;
+    }
+
+    @PostMapping("/inbound")
+    public ResponseEntity<Map<String, Object>> inbound(
+            @RequestBody Map<String, Object> payload,
+            @RequestParam(value = "adapter", required = false) String adapterQuery,
+            @RequestHeader(value = "X-Escalated-Adapter", required = false) String adapterHeader,
+            @RequestHeader(value = "X-Escalated-Inbound-Secret", required = false) String providedSecret) {
+
+        if (!verifySecret(providedSecret)) {
+            return ResponseEntity.status(401).body(Map.of("error", "missing or invalid inbound secret"));
+        }
+
+        String adapter = firstNonEmpty(adapterQuery, adapterHeader);
+        if (adapter == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "missing adapter"));
+        }
+        InboundEmailParser parser = parsersByName.get(adapter.toLowerCase());
+        if (parser == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "unknown adapter: " + adapter));
+        }
+
+        InboundMessage message;
+        try {
+            message = parser.parse(payload);
+        } catch (RuntimeException ex) {
+            log.warn("[InboundEmailController] parse failed for {}: {}", adapter, ex.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid payload"));
+        }
+
+        Optional<Ticket> resolved = router.resolveTicket(message);
+        String status = resolved.isPresent() ? "matched" : "unmatched";
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", status);
+        response.put("ticketId", resolved.map(Ticket::getId).orElse(null));
+        return ResponseEntity.accepted().body(response);
+    }
+
+    private boolean verifySecret(String provided) {
+        String expected = properties.getEmail() == null
+                ? ""
+                : (properties.getEmail().getInboundSecret() == null ? "" : properties.getEmail().getInboundSecret());
+        if (expected.isEmpty() || provided == null) {
+            // Inbound signing not configured → effectively disables
+            // the webhook (prevents accidental unauthenticated routing).
+            return false;
+        }
+        byte[] e = expected.getBytes(StandardCharsets.UTF_8);
+        byte[] p = provided.getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(e, p);
+    }
+
+    private static String firstNonEmpty(String... values) {
+        for (String v : values) {
+            if (v != null && !v.isEmpty()) {
+                return v;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/dev/escalated/services/EmailService.java
+++ b/src/main/java/dev/escalated/services/EmailService.java
@@ -1,7 +1,9 @@
 package dev.escalated.services;
 
+import dev.escalated.config.EscalatedProperties;
 import dev.escalated.models.Reply;
 import dev.escalated.models.Ticket;
+import dev.escalated.services.email.MessageIdUtil;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.slf4j.Logger;
@@ -19,10 +21,15 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
     private final TemplateEngine templateEngine;
+    private final EscalatedProperties properties;
 
-    public EmailService(JavaMailSender mailSender, TemplateEngine templateEngine) {
+    public EmailService(
+            JavaMailSender mailSender,
+            TemplateEngine templateEngine,
+            EscalatedProperties properties) {
         this.mailSender = mailSender;
         this.templateEngine = templateEngine;
+        this.properties = properties;
     }
 
     public void sendTicketCreatedNotification(Ticket ticket) {
@@ -31,8 +38,10 @@ public class EmailService {
         context.setVariable("ticketUrl", "/escalated/tickets/" + ticket.getId());
 
         String htmlContent = templateEngine.process("email/ticket-created", context);
+        String messageId = MessageIdUtil.buildMessageId(
+                ticket.getId(), null, emailDomain());
         sendEmail(ticket.getRequesterEmail(), "Ticket Created: " + ticket.getSubject(),
-                htmlContent, ticket.getEmailMessageId());
+                htmlContent, messageId, null, ticket.getId());
     }
 
     public void sendReplyNotification(Ticket ticket, Reply reply) {
@@ -46,7 +55,14 @@ public class EmailService {
                 : (ticket.getAssignedAgent() != null ? ticket.getAssignedAgent().getEmail() : null);
 
         if (recipient != null) {
-            sendEmail(recipient, "Re: " + ticket.getSubject(), htmlContent, reply.getEmailMessageId());
+            // Reply Message-ID includes reply id; References points back
+            // to the ticket-root Message-ID so clients thread correctly.
+            String replyMessageId = MessageIdUtil.buildMessageId(
+                    ticket.getId(), reply.getId(), emailDomain());
+            String rootMessageId = MessageIdUtil.buildMessageId(
+                    ticket.getId(), null, emailDomain());
+            sendEmail(recipient, "Re: " + ticket.getSubject(), htmlContent,
+                    replyMessageId, rootMessageId, ticket.getId());
         }
     }
 
@@ -56,10 +72,20 @@ public class EmailService {
         context.setVariable("surveyUrl", surveyUrl);
 
         String htmlContent = templateEngine.process("email/satisfaction-survey", context);
-        sendEmail(ticket.getRequesterEmail(), "How was your experience?", htmlContent, null);
+        sendEmail(ticket.getRequesterEmail(), "How was your experience?",
+                htmlContent, null, null, ticket.getId());
     }
 
-    private void sendEmail(String to, String subject, String htmlContent, String messageId) {
+    /**
+     * Internal: send a MIME message with canonical threading + Reply-To
+     * headers. {@code messageId} is the header to set; {@code threadRoot}
+     * (nullable) is the In-Reply-To / References anchor for replies.
+     * {@code ticketId} is used to compute the signed Reply-To so the
+     * inbound provider webhook can verify ticket identity independently
+     * of the Message-ID / In-Reply-To chain.
+     */
+    private void sendEmail(String to, String subject, String htmlContent,
+                           String messageId, String threadRoot, long ticketId) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
@@ -69,12 +95,33 @@ public class EmailService {
 
             if (messageId != null) {
                 message.setHeader("Message-ID", messageId);
-                message.setHeader("References", messageId);
+            }
+            if (threadRoot != null) {
+                message.setHeader("In-Reply-To", threadRoot);
+                message.setHeader("References", threadRoot);
+            }
+
+            // Signed Reply-To so the inbound webhook can verify ticket
+            // identity even when clients strip the Message-ID chain.
+            String secret = emailInboundSecret();
+            if (!secret.isEmpty()) {
+                helper.setReplyTo(
+                        MessageIdUtil.buildReplyTo(ticketId, secret, emailDomain()));
             }
 
             mailSender.send(message);
         } catch (MessagingException ex) {
             log.error("Failed to send email to {}: {}", to, ex.getMessage());
         }
+    }
+
+    private String emailDomain() {
+        String domain = properties.getEmail().getDomain();
+        return (domain == null || domain.isBlank()) ? "localhost" : domain;
+    }
+
+    private String emailInboundSecret() {
+        String secret = properties.getEmail().getInboundSecret();
+        return secret == null ? "" : secret;
     }
 }

--- a/src/main/java/dev/escalated/services/email/MessageIdUtil.java
+++ b/src/main/java/dev/escalated/services/email/MessageIdUtil.java
@@ -1,0 +1,108 @@
+package dev.escalated.services.email;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Pure helpers for RFC 5322 Message-ID threading and signed Reply-To
+ * addresses. Mirrors the NestJS reference
+ * <c>escalated-nestjs/src/services/email/message-id.ts</c>.
+ *
+ * <p>Message-ID format:
+ * <ul>
+ *   <li><code>&lt;ticket-{ticketId}@{domain}&gt;</code> — initial ticket email</li>
+ *   <li><code>&lt;ticket-{ticketId}-reply-{replyId}@{domain}&gt;</code> — agent reply</li>
+ * </ul>
+ *
+ * <p>Signed Reply-To format:
+ * <code>reply+{ticketId}.{hmac8}@{domain}</code>
+ *
+ * <p>The signed Reply-To carries identity even when clients strip our
+ * Message-ID / In-Reply-To headers — inbound provider webhook verifies
+ * the signature before routing the reply to the ticket.
+ */
+public final class MessageIdUtil {
+
+    private static final Pattern TICKET_ID_IN_MSG = Pattern.compile("ticket-(\\d+)(?:-reply-\\d+)?@", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REPLY_LOCAL_PART = Pattern.compile("^reply\\+(\\d+)\\.([a-f0-9]{8})$", Pattern.CASE_INSENSITIVE);
+
+    private MessageIdUtil() {
+        // static helpers only
+    }
+
+    /**
+     * Build an RFC 5322 Message-ID. Pass {@code null} for {@code replyId}
+     * on the initial ticket email; the tail "-reply-{id}" is appended
+     * only when {@code replyId} is non-null.
+     */
+    public static String buildMessageId(long ticketId, Long replyId, String domain) {
+        String body = replyId != null ? "ticket-" + ticketId + "-reply-" + replyId : "ticket-" + ticketId;
+        return "<" + body + "@" + domain + ">";
+    }
+
+    /**
+     * Extract the ticket id from a Message-ID we issued. Accepts the
+     * header value with or without angle brackets. Returns
+     * {@link Optional#empty()} when the input doesn't match our shape.
+     */
+    public static Optional<Long> parseTicketIdFromMessageId(String raw) {
+        if (raw == null) return Optional.empty();
+        Matcher m = TICKET_ID_IN_MSG.matcher(raw);
+        if (!m.find()) return Optional.empty();
+        try {
+            return Optional.of(Long.parseLong(m.group(1)));
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Build a signed Reply-To address. The 8-character HMAC-SHA256
+     * signature over the ticket id + secret prevents tampering.
+     */
+    public static String buildReplyTo(long ticketId, String secret, String domain) {
+        return "reply+" + ticketId + "." + sign(ticketId, secret) + "@" + domain;
+    }
+
+    /**
+     * Verify a full reply-to address (local@domain) or just the local
+     * part. Returns the ticket id on success.
+     */
+    public static Optional<Long> verifyReplyTo(String address, String secret) {
+        if (address == null) return Optional.empty();
+        int at = address.indexOf('@');
+        String local = at > 0 ? address.substring(0, at) : address;
+        Matcher m = REPLY_LOCAL_PART.matcher(local);
+        if (!m.matches()) return Optional.empty();
+        long ticketId;
+        try {
+            ticketId = Long.parseLong(m.group(1));
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+        String expected = sign(ticketId, secret);
+        if (!expected.equalsIgnoreCase(m.group(2))) {
+            return Optional.empty();
+        }
+        return Optional.of(ticketId);
+    }
+
+    private static String sign(long ticketId, String secret) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] digest = mac.doFinal(Long.toString(ticketId).getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(16);
+            for (int i = 0; i < 4; i++) {
+                hex.append(String.format("%02x", digest[i]));
+            }
+            return hex.toString();
+        } catch (Exception ex) {
+            throw new IllegalStateException("HMAC-SHA256 unavailable", ex);
+        }
+    }
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundAttachment.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundAttachment.java
@@ -1,0 +1,15 @@
+package dev.escalated.services.email.inbound;
+
+/**
+ * Inbound attachment. Providers either inline the content (small
+ * attachments) or supply a URL to download it from (larger
+ * provider-hosted attachments).
+ */
+public record InboundAttachment(
+        String name,
+        String contentType,
+        Long sizeBytes,
+        byte[] content,
+        String downloadUrl
+) {
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundEmailParser.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundEmailParser.java
@@ -1,0 +1,27 @@
+package dev.escalated.services.email.inbound;
+
+/**
+ * Transport-specific parser that normalizes a provider's webhook
+ * payload into an {@link InboundMessage}. Implementations register
+ * themselves as Spring beans and are resolved by {@link #name()}
+ * (matches the adapter label on the inbound webhook request).
+ *
+ * <p>Add a new provider by implementing this interface; the inbound
+ * controller will pick it up via DI when the request's adapter label
+ * matches {@link #name()}.
+ */
+public interface InboundEmailParser {
+
+    /**
+     * Short provider name. Must match the value in the
+     * {@code ?adapter=...} query parameter or the
+     * {@code X-Escalated-Adapter} header on the inbound webhook.
+     */
+    String name();
+
+    /**
+     * Parse a raw webhook payload (e.g. a provider-specific JSON
+     * object) into an {@link InboundMessage}.
+     */
+    InboundMessage parse(Object rawPayload);
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundEmailRouter.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundEmailRouter.java
@@ -1,0 +1,125 @@
+package dev.escalated.services.email.inbound;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.Ticket;
+import dev.escalated.repositories.TicketRepository;
+import dev.escalated.services.email.MessageIdUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves an inbound email to an existing ticket via canonical
+ * Message-ID parsing + signed Reply-To verification.
+ *
+ * <p>Resolution order (first match wins):
+ * <ol>
+ *   <li>{@code In-Reply-To} parsed via {@link MessageIdUtil#parseTicketIdFromMessageId}
+ *       — cold-start path, no DB lookup on the header value required
+ *       (we know our own Message-ID format).</li>
+ *   <li>{@code References} parsed via {@link MessageIdUtil#parseTicketIdFromMessageId},
+ *       each id in order.</li>
+ *   <li>Signed Reply-To on {@link InboundMessage#toEmail()}
+ *       ({@code reply+{id}.{hmac8}@...}) verified via
+ *       {@link MessageIdUtil#verifyReplyTo}. Survives clients that
+ *       strip our threading headers; forged signatures are rejected
+ *       with a timing-safe HMAC comparison.</li>
+ *   <li>Subject line reference tag (e.g. {@code [ESC-00001]}) — legacy.</li>
+ *   <li>Audit-log lookup — not implemented in this PR; the row is
+ *       inserted by the inbound controller once the service lands.</li>
+ * </ol>
+ *
+ * <p>Mirrors the NestJS {@code InboundRouterService} resolution order
+ * and the Laravel/Rails/Django/Adonis/WordPress/.NET ports.
+ */
+@Service
+public class InboundEmailRouter {
+
+    private static final Logger log = LoggerFactory.getLogger(InboundEmailRouter.class);
+
+    private final TicketRepository ticketRepository;
+    private final EscalatedProperties properties;
+
+    public InboundEmailRouter(TicketRepository ticketRepository, EscalatedProperties properties) {
+        this.ticketRepository = ticketRepository;
+        this.properties = properties;
+    }
+
+    /**
+     * Resolve the inbound email to an existing ticket, or
+     * {@link Optional#empty()} when no match (caller should create a
+     * new ticket).
+     */
+    public Optional<Ticket> resolveTicket(InboundMessage message) {
+        if (message == null) {
+            return Optional.empty();
+        }
+
+        List<String> headerIds = candidateHeaderMessageIds(message);
+
+        // 1 + 2. Parse canonical Message-IDs out of our own headers.
+        for (String raw : headerIds) {
+            Optional<Long> ticketId = MessageIdUtil.parseTicketIdFromMessageId(raw);
+            if (ticketId.isPresent()) {
+                Optional<Ticket> ticket = ticketRepository.findById(ticketId.get());
+                if (ticket.isPresent()) {
+                    return ticket;
+                }
+            }
+        }
+
+        // 3. Signed Reply-To on the recipient address.
+        String secret = properties.getEmail() == null ? null : properties.getEmail().getInboundSecret();
+        if (secret != null && !secret.isBlank() && message.toEmail() != null) {
+            Optional<Long> verified = MessageIdUtil.verifyReplyTo(message.toEmail(), secret);
+            if (verified.isPresent()) {
+                Optional<Ticket> ticket = ticketRepository.findById(verified.get());
+                if (ticket.isPresent()) {
+                    return ticket;
+                }
+                log.debug("[InboundEmailRouter] Reply-To verified but ticket #{} not found", verified.get());
+            }
+        }
+
+        // 4. Subject line reference tag.
+        if (message.subject() != null) {
+            Matcher m = SUBJECT_REF_PATTERN.matcher(message.subject());
+            if (m.find()) {
+                // Ticket reference is stored in the ticket_number column.
+                Optional<Ticket> ticket = ticketRepository.findByTicketNumber(m.group(1));
+                if (ticket.isPresent()) {
+                    return ticket;
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Return every candidate Message-ID from the inbound headers in
+     * the order the mail client sent them. Caller iterates the
+     * result and stops at the first resolvable id.
+     */
+    public static List<String> candidateHeaderMessageIds(InboundMessage message) {
+        List<String> ids = new ArrayList<>();
+        if (message.inReplyTo() != null && !message.inReplyTo().isBlank()) {
+            ids.add(message.inReplyTo().trim());
+        }
+        if (message.references() != null && !message.references().isBlank()) {
+            for (String raw : message.references().trim().split("\\s+")) {
+                if (!raw.isBlank()) {
+                    ids.add(raw);
+                }
+            }
+        }
+        return ids;
+    }
+
+    private static final Pattern SUBJECT_REF_PATTERN = Pattern.compile("\\[([A-Z]+-[0-9A-Z-]+)\\]");
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundEmailService.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundEmailService.java
@@ -1,0 +1,146 @@
+package dev.escalated.services.email.inbound;
+
+import dev.escalated.models.Reply;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketPriority;
+import dev.escalated.services.TicketService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Orchestrates the full inbound email pipeline:
+ * <pre>parser output → router resolution → reply-on-existing or
+ * create-new-ticket</pre>
+ *
+ * <p>Called from {@link dev.escalated.controllers.InboundEmailController}
+ * after the parser normalizes the provider payload. Mirrors the
+ * NestJS reference {@code InboundRouterService} and the .NET
+ * {@code InboundEmailService}.
+ *
+ * <p>Attachment persistence is out of scope here: provider-hosted
+ * attachments (Mailgun) carry their {@code downloadUrl} through to
+ * {@link ProcessResult#pendingAttachmentDownloads()} so a follow-up
+ * worker can fetch + persist out-of-band.
+ */
+@Service
+public class InboundEmailService {
+
+    private static final Logger log = LoggerFactory.getLogger(InboundEmailService.class);
+
+    private final InboundEmailRouter router;
+    private final TicketService ticketService;
+
+    public InboundEmailService(InboundEmailRouter router, TicketService ticketService) {
+        this.router = router;
+        this.ticketService = ticketService;
+    }
+
+    /**
+     * Process a parsed inbound message. Returns a {@link ProcessResult}
+     * carrying the outcome (matched + reply id, created new ticket
+     * id, or skipped).
+     */
+    public ProcessResult process(InboundMessage message) {
+        Optional<Ticket> ticketMatch = router.resolveTicket(message);
+
+        if (ticketMatch.isPresent()) {
+            Ticket ticket = ticketMatch.get();
+            Reply reply = ticketService.addReply(
+                    ticket.getId(),
+                    message.body(),
+                    message.fromName(),
+                    message.fromEmail(),
+                    "inbound_email",
+                    false
+            );
+            return new ProcessResult(
+                    Outcome.REPLIED_TO_EXISTING,
+                    ticket.getId(),
+                    reply.getId(),
+                    pendingDownloads(message)
+            );
+        }
+
+        if (isNoiseEmail(message)) {
+            return new ProcessResult(Outcome.SKIPPED, null, null, List.of());
+        }
+
+        Ticket newTicket = ticketService.create(
+                nonBlankOr(message.subject(), "(no subject)"),
+                message.body(),
+                message.fromName(),
+                message.fromEmail(),
+                TicketPriority.MEDIUM,
+                null
+        );
+        log.info("[InboundEmailService] Created ticket #{} from inbound email", newTicket.getId());
+
+        return new ProcessResult(
+                Outcome.CREATED_NEW,
+                newTicket.getId(),
+                null,
+                pendingDownloads(message)
+        );
+    }
+
+    /**
+     * Noise emails: empty body + empty subject, or from common
+     * bounce/no-reply senders.
+     */
+    static boolean isNoiseEmail(InboundMessage message) {
+        if ("no-reply@sns.amazonaws.com".equalsIgnoreCase(message.fromEmail())) {
+            return true;
+        }
+        boolean bodyEmpty = message.body() == null || message.body().isBlank();
+        boolean subjectEmpty = message.subject() == null || message.subject().isBlank();
+        return bodyEmpty && subjectEmpty;
+    }
+
+    private static String nonBlankOr(String value, String fallback) {
+        return (value == null || value.isBlank()) ? fallback : value;
+    }
+
+    private static List<PendingAttachment> pendingDownloads(InboundMessage message) {
+        List<PendingAttachment> list = new ArrayList<>();
+        if (message.attachments() == null) {
+            return list;
+        }
+        for (InboundAttachment a : message.attachments()) {
+            if (a.downloadUrl() != null && a.content() == null) {
+                list.add(new PendingAttachment(
+                        a.name(),
+                        a.contentType(),
+                        a.sizeBytes(),
+                        a.downloadUrl()
+                ));
+            }
+        }
+        return list;
+    }
+
+    public enum Outcome {
+        REPLIED_TO_EXISTING,
+        CREATED_NEW,
+        SKIPPED
+    }
+
+    public record ProcessResult(
+            Outcome outcome,
+            Long ticketId,
+            Long replyId,
+            List<PendingAttachment> pendingAttachmentDownloads
+    ) {
+    }
+
+    public record PendingAttachment(
+            String name,
+            String contentType,
+            Long sizeBytes,
+            String downloadUrl
+    ) {
+    }
+}

--- a/src/main/java/dev/escalated/services/email/inbound/InboundMessage.java
+++ b/src/main/java/dev/escalated/services/email/inbound/InboundMessage.java
@@ -1,0 +1,45 @@
+package dev.escalated.services.email.inbound;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Transport-agnostic representation of an inbound email, independent
+ * of the source adapter (Postmark, Mailgun, SES, IMAP, etc.).
+ *
+ * <p>Adapters normalize their webhook payload into this shape; the
+ * {@link InboundEmailRouter} then resolves it to a ticket by parsing
+ * canonical Message-IDs out of {@code inReplyTo} / {@code references}
+ * and verifying the signed Reply-To on {@code toEmail}.
+ *
+ * <p>Mirrors the NestJS reference and the per-framework ports.
+ */
+public record InboundMessage(
+        String fromEmail,
+        String fromName,
+        String toEmail,
+        String subject,
+        String bodyText,
+        String bodyHtml,
+        String messageId,
+        String inReplyTo,
+        String references,
+        Map<String, String> headers,
+        List<InboundAttachment> attachments
+) {
+
+    public InboundMessage {
+        headers = headers == null ? Map.of() : headers;
+        attachments = attachments == null ? List.of() : attachments;
+    }
+
+    /**
+     * Best body content (plain text preferred, HTML fallback).
+     */
+    public String body() {
+        if (bodyText != null && !bodyText.isEmpty()) {
+            return bodyText;
+        }
+        return bodyHtml != null ? bodyHtml : "";
+    }
+}

--- a/src/main/java/dev/escalated/services/email/inbound/MailgunInboundParser.java
+++ b/src/main/java/dev/escalated/services/email/inbound/MailgunInboundParser.java
@@ -1,0 +1,135 @@
+package dev.escalated.services.email.inbound;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses Mailgun's inbound webhook payload into an
+ * {@link InboundMessage}. Mailgun POSTs {@code multipart/form-data}
+ * with snake-case field names: {@code sender}, {@code recipient},
+ * {@code subject}, {@code body-plain}, {@code body-html},
+ * {@code Message-Id}, {@code In-Reply-To}, {@code References}, plus
+ * a JSON-encoded {@code attachments} field.
+ *
+ * <p>The Spring controller already ingests a
+ * {@code Map<String,Object>} from the webhook body, so this parser
+ * just reads from that map.
+ *
+ * <p>Mailgun hosts attachment content behind provider URLs (for
+ * large attachments); we carry the URL through in
+ * {@link InboundAttachment#downloadUrl} so a follow-up worker can
+ * fetch + persist out-of-band.
+ */
+@Component
+public class MailgunInboundParser implements InboundEmailParser {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String name() {
+        return "mailgun";
+    }
+
+    @Override
+    public InboundMessage parse(Object rawPayload) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = rawPayload instanceof Map<?, ?> m
+                ? (Map<String, Object>) m
+                : MAPPER.convertValue(rawPayload, new TypeReference<Map<String, Object>>() {});
+
+        String fromEmail = stringAt(payload, "sender");
+        if (fromEmail == null || fromEmail.isEmpty()) {
+            fromEmail = stringAt(payload, "from");
+        }
+        String fromName = extractFromName(stringAt(payload, "from"));
+
+        String toEmail = stringAt(payload, "recipient");
+        if (toEmail == null || toEmail.isEmpty()) {
+            toEmail = stringAt(payload, "To");
+        }
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        putIfNonEmpty(headers, "Message-ID", stringAt(payload, "Message-Id"));
+        putIfNonEmpty(headers, "In-Reply-To", stringAt(payload, "In-Reply-To"));
+        putIfNonEmpty(headers, "References", stringAt(payload, "References"));
+
+        return new InboundMessage(
+                fromEmail == null ? "" : fromEmail,
+                fromName,
+                toEmail == null ? "" : toEmail,
+                stringAt(payload, "subject"),
+                stringAt(payload, "body-plain"),
+                stringAt(payload, "body-html"),
+                stringAt(payload, "Message-Id"),
+                stringAt(payload, "In-Reply-To"),
+                stringAt(payload, "References"),
+                headers,
+                extractAttachments(stringAt(payload, "attachments"))
+        );
+    }
+
+    private static String stringAt(Map<String, Object> payload, String key) {
+        Object v = payload.get(key);
+        return v == null ? null : v.toString();
+    }
+
+    private static void putIfNonEmpty(Map<String, String> headers, String key, String value) {
+        if (value != null && !value.isEmpty()) {
+            headers.put(key, value);
+        }
+    }
+
+    /**
+     * Mailgun's {@code from} field is typically
+     * {@code "Full Name <email@host>"} — extract the display name
+     * portion. Returns {@code null} when the input has no angle-
+     * bracketed email (bare email address).
+     */
+    private static String extractFromName(String raw) {
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        int angle = raw.indexOf('<');
+        if (angle <= 0) {
+            return null;
+        }
+        String name = raw.substring(0, angle).trim();
+        // Strip surrounding quotes if present.
+        if (name.length() >= 2 && name.startsWith("\"") && name.endsWith("\"")) {
+            name = name.substring(1, name.length() - 1);
+        }
+        return name.isEmpty() ? null : name;
+    }
+
+    private static List<InboundAttachment> extractAttachments(String attachmentsJson) {
+        if (attachmentsJson == null || attachmentsJson.isEmpty()) {
+            return new ArrayList<>();
+        }
+        try {
+            List<Map<String, Object>> entries = MAPPER.readValue(
+                    attachmentsJson, new TypeReference<List<Map<String, Object>>>() {});
+            List<InboundAttachment> list = new ArrayList<>();
+            for (Map<String, Object> entry : entries) {
+                String name = stringAt(entry, "name");
+                String contentType = stringAt(entry, "content-type");
+                Long size = entry.get("size") instanceof Number n ? n.longValue() : null;
+                String url = stringAt(entry, "url");
+                list.add(new InboundAttachment(
+                        name == null ? "attachment" : name,
+                        contentType == null ? "application/octet-stream" : contentType,
+                        size,
+                        null,
+                        url
+                ));
+            }
+            return list;
+        } catch (Exception ex) {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/dev/escalated/services/email/inbound/PostmarkInboundParser.java
+++ b/src/main/java/dev/escalated/services/email/inbound/PostmarkInboundParser.java
@@ -1,0 +1,125 @@
+package dev.escalated.services.email.inbound;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses Postmark's inbound webhook payload into an
+ * {@link InboundMessage}. Postmark POSTs a JSON body with
+ * {@code FromFull} / {@code ToFull} / {@code Subject} / {@code TextBody}
+ * / {@code HtmlBody} / {@code Headers} / {@code Attachments} fields.
+ *
+ * <p>Register additional providers (Mailgun, SES) by implementing
+ * {@link InboundEmailParser} as Spring {@code @Component}s — the
+ * controller selects by {@link #name()}.
+ */
+@Component
+public class PostmarkInboundParser implements InboundEmailParser {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String name() {
+        return "postmark";
+    }
+
+    @Override
+    public InboundMessage parse(Object rawPayload) {
+        JsonNode root = MAPPER.valueToTree(rawPayload);
+
+        JsonNode fromFull = root.path("FromFull");
+        String fromEmail = fromFull.path("Email").asText(root.path("From").asText(""));
+        String fromName = fromFull.path("Name").asText(null);
+
+        String toEmail = root.path("OriginalRecipient").asText(null);
+        if (toEmail == null || toEmail.isEmpty()) {
+            toEmail = firstToEmail(root);
+        }
+        if (toEmail == null || toEmail.isEmpty()) {
+            toEmail = root.path("To").asText("");
+        }
+
+        Map<String, String> headers = extractHeaders(root);
+
+        return new InboundMessage(
+                fromEmail,
+                fromName,
+                toEmail,
+                root.path("Subject").asText(""),
+                textOrNull(root, "TextBody"),
+                textOrNull(root, "HtmlBody"),
+                firstNonEmpty(textOrNull(root, "MessageID"), headers.get("Message-ID")),
+                headers.get("In-Reply-To"),
+                headers.get("References"),
+                headers,
+                extractAttachments(root)
+        );
+    }
+
+    private static String firstToEmail(JsonNode root) {
+        JsonNode toFull = root.path("ToFull");
+        if (!toFull.isArray()) {
+            return null;
+        }
+        for (JsonNode entry : toFull) {
+            String email = entry.path("Email").asText(null);
+            if (email != null && !email.isEmpty()) {
+                return email;
+            }
+        }
+        return null;
+    }
+
+    private static Map<String, String> extractHeaders(JsonNode root) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        JsonNode arr = root.path("Headers");
+        if (!arr.isArray()) {
+            return headers;
+        }
+        for (JsonNode entry : arr) {
+            String name = entry.path("Name").asText(null);
+            String value = entry.path("Value").asText(null);
+            if (name != null && !name.isEmpty() && value != null) {
+                headers.put(name, value);
+            }
+        }
+        return headers;
+    }
+
+    private static List<InboundAttachment> extractAttachments(JsonNode root) {
+        List<InboundAttachment> list = new ArrayList<>();
+        JsonNode arr = root.path("Attachments");
+        if (!arr.isArray()) {
+            return list;
+        }
+        for (JsonNode entry : arr) {
+            String name = entry.path("Name").asText("attachment");
+            String contentType = entry.path("ContentType").asText("application/octet-stream");
+            Long size = entry.has("ContentLength") ? entry.path("ContentLength").asLong() : null;
+            String contentBase64 = textOrNull(entry, "Content");
+            byte[] content = contentBase64 != null ? Base64.getDecoder().decode(contentBase64) : null;
+            list.add(new InboundAttachment(name, contentType, size, content, null));
+        }
+        return list;
+    }
+
+    private static String textOrNull(JsonNode parent, String field) {
+        JsonNode node = parent.path(field);
+        return node.isMissingNode() || node.isNull() ? null : node.asText(null);
+    }
+
+    private static String firstNonEmpty(String... values) {
+        for (String v : values) {
+            if (v != null && !v.isEmpty()) {
+                return v;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/dev/escalated/services/EmailServiceTest.java
+++ b/src/test/java/dev/escalated/services/EmailServiceTest.java
@@ -1,0 +1,144 @@
+package dev.escalated.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.AgentProfile;
+import dev.escalated.models.Reply;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketPriority;
+import dev.escalated.models.TicketStatus;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.thymeleaf.TemplateEngine;
+
+/**
+ * Unit tests for {@link EmailService}'s Message-ID / Reply-To wiring.
+ *
+ * <p>Uses a real {@link MimeMessage} + a {@link Mock} JavaMailSender so
+ * we can assert on the headers that the service actually sets. The
+ * Thymeleaf template engine is mocked to avoid pulling in real
+ * templates for these unit tests.
+ */
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @Mock private JavaMailSender mailSender;
+    @Mock private TemplateEngine templateEngine;
+
+    private EmailService service;
+    private EscalatedProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new EscalatedProperties();
+        properties.getEmail().setDomain("support.example.com");
+        properties.getEmail().setInboundSecret("test-secret-for-hmac");
+        service = new EmailService(mailSender, templateEngine, properties);
+
+        // Stub JavaMailSender so createMimeMessage returns a real
+        // MimeMessage we can inspect. Use a no-op session.
+        Session session = Session.getDefaultInstance(new Properties());
+        when(mailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage(session));
+        when(templateEngine.process(any(String.class), any())).thenReturn("<p>rendered</p>");
+    }
+
+    private Ticket newTicket() {
+        Ticket t = new Ticket();
+        t.setId(42L);
+        t.setSubject("Help");
+        t.setStatus(TicketStatus.OPEN);
+        t.setPriority(TicketPriority.MEDIUM);
+        t.setRequesterEmail("alice@example.com");
+        return t;
+    }
+
+    @Test
+    void sendTicketCreatedNotification_setsCanonicalMessageIdAndSignedReplyTo() throws Exception {
+        service.sendTicketCreatedNotification(newTicket());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        String[] messageId = sent.getHeader("Message-ID");
+        assertThat(messageId).isNotNull();
+        assertThat(messageId[0]).isEqualTo("<ticket-42@support.example.com>");
+
+        // No In-Reply-To on the initial notification (thread anchor).
+        assertThat(sent.getHeader("In-Reply-To")).isNull();
+
+        String[] replyTo = sent.getHeader("Reply-To");
+        assertThat(replyTo).isNotNull();
+        assertThat(replyTo[0]).matches("reply\\+42\\.[a-f0-9]{8}@support\\.example\\.com");
+    }
+
+    @Test
+    void sendReplyNotification_addsInReplyToAndReferencesPointingToTicketRoot() throws Exception {
+        Ticket ticket = newTicket();
+        AgentProfile agent = new AgentProfile();
+        agent.setEmail("agent@example.com");
+        ticket.setAssignedAgent(agent);
+
+        Reply reply = new Reply();
+        reply.setId(7L);
+        reply.setAuthorType("requester"); // requester reply → goes to agent
+        reply.setTicket(ticket);
+
+        service.sendReplyNotification(ticket, reply);
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        assertThat(sent.getHeader("Message-ID")[0])
+                .isEqualTo("<ticket-42-reply-7@support.example.com>");
+        assertThat(sent.getHeader("In-Reply-To")[0])
+                .isEqualTo("<ticket-42@support.example.com>");
+        assertThat(sent.getHeader("References")[0])
+                .isEqualTo("<ticket-42@support.example.com>");
+    }
+
+    @Test
+    void sendEmail_whenInboundSecretBlank_doesNotSetReplyTo() throws Exception {
+        properties.getEmail().setInboundSecret("");
+
+        service.sendTicketCreatedNotification(newTicket());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        // Message-ID still present; Reply-To omitted when we have no key.
+        assertThat(sent.getHeader("Message-ID")).isNotNull();
+        assertThat(sent.getHeader("Reply-To")).isNull();
+    }
+
+    @Test
+    void sendSatisfactionSurvey_doesNotSetMessageId_butStillSetsReplyTo() throws Exception {
+        service.sendSatisfactionSurvey(newTicket(), "https://example.com/survey");
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        // Survey is not part of the ticket thread — no Message-ID /
+        // In-Reply-To chain needed. But the Reply-To still routes back
+        // to the ticket so replies (e.g. "what about this other issue")
+        // land on the right ticket id.
+        assertThat(sent.getHeader("Message-ID")).isNull();
+        assertThat(sent.getHeader("In-Reply-To")).isNull();
+        assertThat(sent.getHeader("Reply-To")).isNotNull();
+    }
+}

--- a/src/test/java/dev/escalated/services/email/MessageIdUtilTest.java
+++ b/src/test/java/dev/escalated/services/email/MessageIdUtilTest.java
@@ -1,0 +1,119 @@
+package dev.escalated.services.email;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link MessageIdUtil}. Mirrors the NestJS test suite
+ * for {@code message-id.ts}. Pure functions — no Spring context.
+ */
+class MessageIdUtilTest {
+
+    private static final String DOMAIN = "support.example.com";
+    private static final String SECRET = "test-secret-long-enough-for-hmac";
+
+    @Test
+    void buildMessageId_initialTicket_usesTicketForm() {
+        String id = MessageIdUtil.buildMessageId(42, null, DOMAIN);
+        assertThat(id).isEqualTo("<ticket-42@support.example.com>");
+    }
+
+    @Test
+    void buildMessageId_replyForm_appendsReplyId() {
+        String id = MessageIdUtil.buildMessageId(42, 7L, DOMAIN);
+        assertThat(id).isEqualTo("<ticket-42-reply-7@support.example.com>");
+    }
+
+    @Test
+    void parseTicketIdFromMessageId_roundTripsBuiltId() {
+        String initial = MessageIdUtil.buildMessageId(42, null, DOMAIN);
+        String reply = MessageIdUtil.buildMessageId(42, 7L, DOMAIN);
+
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId(initial)).contains(42L);
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId(reply)).contains(42L);
+    }
+
+    @Test
+    void parseTicketIdFromMessageId_acceptsValueWithoutBrackets() {
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("ticket-99@example.com")).contains(99L);
+    }
+
+    @Test
+    void parseTicketIdFromMessageId_returnsEmptyForUnrelatedInput() {
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId(null)).isEmpty();
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("")).isEmpty();
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("<random@mail.com>")).isEmpty();
+        assertThat(MessageIdUtil.parseTicketIdFromMessageId("ticket-abc@example.com")).isEmpty();
+    }
+
+    @Test
+    void buildReplyTo_isStableForSameInputs() {
+        String first = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String again = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+
+        assertThat(first).isEqualTo(again);
+        assertThat(first).matches("reply\\+42\\.[a-f0-9]{8}@support\\.example\\.com");
+    }
+
+    @Test
+    void buildReplyTo_differentTicketsProduceDifferentSignatures() {
+        String a = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String b = MessageIdUtil.buildReplyTo(43, SECRET, DOMAIN);
+
+        // Local parts differ in both the ticket id and the signature.
+        String aLocal = a.substring(0, a.indexOf('@'));
+        String bLocal = b.substring(0, b.indexOf('@'));
+        assertThat(aLocal).isNotEqualTo(bLocal);
+    }
+
+    @Test
+    void verifyReplyTo_roundTripsBuiltAddress() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        assertThat(MessageIdUtil.verifyReplyTo(address, SECRET)).contains(42L);
+    }
+
+    @Test
+    void verifyReplyTo_acceptsLocalPartOnly() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String local = address.substring(0, address.indexOf('@'));
+        assertThat(MessageIdUtil.verifyReplyTo(local, SECRET)).contains(42L);
+    }
+
+    @Test
+    void verifyReplyTo_rejectsTamperedSignature() {
+        // Build a valid address, then flip one signature char.
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        int at = address.indexOf('@');
+        String local = address.substring(0, at);
+        String tampered = local.substring(0, local.length() - 1)
+                + (local.charAt(local.length() - 1) == '0' ? '1' : '0')
+                + address.substring(at);
+
+        assertThat(MessageIdUtil.verifyReplyTo(tampered, SECRET)).isEmpty();
+    }
+
+    @Test
+    void verifyReplyTo_rejectsWrongSecret() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        assertThat(MessageIdUtil.verifyReplyTo(address, "different-secret")).isEmpty();
+    }
+
+    @Test
+    void verifyReplyTo_rejectsMalformedInput() {
+        Optional<Long> empty = Optional.empty();
+        assertThat(MessageIdUtil.verifyReplyTo(null, SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("", SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("alice@example.com", SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("reply@example.com", SECRET)).isEqualTo(empty);
+        assertThat(MessageIdUtil.verifyReplyTo("reply+abc.deadbeef@example.com", SECRET)).isEqualTo(empty);
+    }
+
+    @Test
+    void verifyReplyTo_isCaseInsensitiveOnHex() {
+        String address = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        String upper = address.toUpperCase();
+        assertThat(MessageIdUtil.verifyReplyTo(upper, SECRET)).contains(42L);
+    }
+}

--- a/src/test/java/dev/escalated/services/email/inbound/InboundEmailRouterTest.java
+++ b/src/test/java/dev/escalated/services/email/inbound/InboundEmailRouterTest.java
@@ -1,0 +1,160 @@
+package dev.escalated.services.email.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.Ticket;
+import dev.escalated.repositories.TicketRepository;
+import dev.escalated.services.email.MessageIdUtil;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InboundEmailRouterTest {
+
+    private static final String DOMAIN = "support.example.com";
+    private static final String SECRET = "test-secret-for-hmac";
+
+    @Mock private TicketRepository ticketRepository;
+
+    private EscalatedProperties properties;
+    private InboundEmailRouter router;
+
+    @BeforeEach
+    void setUp() {
+        properties = new EscalatedProperties();
+        properties.getEmail().setDomain(DOMAIN);
+        router = new InboundEmailRouter(ticketRepository, properties);
+    }
+
+    private Ticket mockTicket(long id, String reference) {
+        Ticket t = new Ticket();
+        t.setId(id);
+        t.setTicketNumber(reference);
+        return t;
+    }
+
+    private InboundMessage message(String inReplyTo, String references, String toEmail, String subject) {
+        return new InboundMessage(
+                "customer@example.com",
+                "Customer",
+                toEmail,
+                subject,
+                "body",
+                null,
+                null,
+                inReplyTo,
+                references,
+                Map.of(),
+                List.of()
+        );
+    }
+
+    @Test
+    void resolveTicket_matchesCanonicalInReplyTo() {
+        Ticket ticket = mockTicket(42, "ESC-00042");
+        when(ticketRepository.findById(42L)).thenReturn(Optional.of(ticket));
+
+        InboundMessage m = message(
+                "<ticket-42@support.example.com>", null, "support@example.com", "re: hi");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_matchesReferencesHeaderCanonicalMessageId() {
+        Ticket ticket = mockTicket(42, "ESC-00042");
+        when(ticketRepository.findById(42L)).thenReturn(Optional.of(ticket));
+
+        InboundMessage m = message(
+                null,
+                "<unrelated@mail.com> <ticket-42@support.example.com>",
+                "support@example.com",
+                "re: hi");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_verifiesSignedReplyToWhenSecretConfigured() {
+        properties.getEmail().setInboundSecret(SECRET);
+        Ticket ticket = mockTicket(42, "ESC-00042");
+        when(ticketRepository.findById(42L)).thenReturn(Optional.of(ticket));
+
+        String to = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        InboundMessage m = message(null, null, to, "my issue");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_rejectsForgedReplyToSignature() {
+        properties.getEmail().setInboundSecret("real-secret");
+
+        String forged = MessageIdUtil.buildReplyTo(42, "wrong-secret", DOMAIN);
+        InboundMessage m = message(null, null, forged, "try to take over");
+
+        assertThat(router.resolveTicket(m)).isEmpty();
+    }
+
+    @Test
+    void resolveTicket_ignoresSignedReplyToWhenSecretBlank() {
+        // Even a valid address signed with SOME secret must be
+        // ignored when the host hasn't configured one.
+        String to = MessageIdUtil.buildReplyTo(42, SECRET, DOMAIN);
+        InboundMessage m = message(null, null, to, "hi");
+
+        assertThat(router.resolveTicket(m)).isEmpty();
+    }
+
+    @Test
+    void resolveTicket_matchesSubjectReferenceTag() {
+        Ticket ticket = mockTicket(99, "ESC-00099");
+        when(ticketRepository.findByTicketNumber("ESC-00099")).thenReturn(Optional.of(ticket));
+
+        InboundMessage m = message(null, null, "support@example.com", "RE: [ESC-00099] help");
+
+        assertThat(router.resolveTicket(m)).contains(ticket);
+    }
+
+    @Test
+    void resolveTicket_returnsEmptyWhenNothingMatches() {
+        InboundMessage m = message(null, null, "support@example.com", "New issue");
+
+        assertThat(router.resolveTicket(m)).isEmpty();
+    }
+
+    @Test
+    void resolveTicket_nullMessageReturnsEmpty() {
+        assertThat(router.resolveTicket(null)).isEmpty();
+    }
+
+    @Test
+    void candidateHeaderMessageIds_inReplyToFirstThenReferences() {
+        InboundMessage m = message(
+                "<primary@mail>",
+                "<a@mail> <b@mail>",
+                "support@example.com",
+                "re");
+
+        List<String> ids = InboundEmailRouter.candidateHeaderMessageIds(m);
+
+        assertThat(ids).containsExactly("<primary@mail>", "<a@mail>", "<b@mail>");
+    }
+
+    @Test
+    void candidateHeaderMessageIds_emptyHeadersYieldsNone() {
+        InboundMessage m = message(null, null, "support@example.com", "hi");
+
+        assertThat(InboundEmailRouter.candidateHeaderMessageIds(m)).isEmpty();
+    }
+}

--- a/src/test/java/dev/escalated/services/email/inbound/MailgunInboundParserTest.java
+++ b/src/test/java/dev/escalated/services/email/inbound/MailgunInboundParserTest.java
@@ -1,0 +1,114 @@
+package dev.escalated.services.email.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MailgunInboundParserTest {
+
+    private Map<String, Object> sampleFormData() {
+        Map<String, Object> m = new HashMap<>();
+        m.put("sender", "customer@example.com");
+        m.put("from", "Customer <customer@example.com>");
+        m.put("recipient", "support+abc@support.example.com");
+        m.put("To", "support+abc@support.example.com");
+        m.put("subject", "[ESC-00042] Help");
+        m.put("body-plain", "Plain body");
+        m.put("body-html", "<p>HTML body</p>");
+        m.put("Message-Id", "<mailgun-incoming@mail.client>");
+        m.put("In-Reply-To", "<ticket-42@support.example.com>");
+        m.put("References", "<ticket-42@support.example.com>");
+        m.put("attachments",
+                "[{\"name\":\"report.pdf\",\"content-type\":\"application/pdf\",\"size\":5120,\"url\":\"https://mailgun.example/att/abc\"}]");
+        return m;
+    }
+
+    @Test
+    void nameIsMailgun() {
+        assertThat(new MailgunInboundParser().name()).isEqualTo("mailgun");
+    }
+
+    @Test
+    void parseExtractsCoreFields() {
+        InboundMessage m = new MailgunInboundParser().parse(sampleFormData());
+
+        assertThat(m.fromEmail()).isEqualTo("customer@example.com");
+        assertThat(m.fromName()).isEqualTo("Customer");
+        assertThat(m.toEmail()).isEqualTo("support+abc@support.example.com");
+        assertThat(m.subject()).isEqualTo("[ESC-00042] Help");
+        assertThat(m.bodyText()).isEqualTo("Plain body");
+        assertThat(m.bodyHtml()).isEqualTo("<p>HTML body</p>");
+    }
+
+    @Test
+    void parseExtractsThreadingHeaders() {
+        InboundMessage m = new MailgunInboundParser().parse(sampleFormData());
+
+        assertThat(m.inReplyTo()).isEqualTo("<ticket-42@support.example.com>");
+        assertThat(m.references()).isEqualTo("<ticket-42@support.example.com>");
+    }
+
+    @Test
+    void parseProviderHostedAttachments() {
+        InboundMessage m = new MailgunInboundParser().parse(sampleFormData());
+
+        assertThat(m.attachments()).hasSize(1);
+        InboundAttachment a = m.attachments().get(0);
+        assertThat(a.name()).isEqualTo("report.pdf");
+        assertThat(a.contentType()).isEqualTo("application/pdf");
+        assertThat(a.sizeBytes()).isEqualTo(5120L);
+        assertThat(a.downloadUrl()).isEqualTo("https://mailgun.example/att/abc");
+        // Mailgun hosts content — no inline bytes.
+        assertThat(a.content()).isNull();
+    }
+
+    @Test
+    void parseHandlesMalformedAttachmentsJson() {
+        Map<String, Object> data = sampleFormData();
+        data.put("attachments", "not json");
+
+        InboundMessage m = new MailgunInboundParser().parse(data);
+
+        assertThat(m.attachments()).isEmpty();
+    }
+
+    @Test
+    void parseFallsBackSenderToFromOnMissing() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("from", "only-from@example.com");
+        data.put("recipient", "support@example.com");
+        data.put("subject", "hi");
+
+        InboundMessage m = new MailgunInboundParser().parse(data);
+
+        assertThat(m.fromEmail()).isEqualTo("only-from@example.com");
+    }
+
+    @Test
+    void parseExtractFromNameReturnsNullWithoutAngleBrackets() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("sender", "bareemail@example.com");
+        data.put("from", "bareemail@example.com");
+        data.put("recipient", "support@example.com");
+        data.put("subject", "hi");
+
+        InboundMessage m = new MailgunInboundParser().parse(data);
+
+        assertThat(m.fromName()).isNull();
+    }
+
+    @Test
+    void parseStripsQuotesFromFromName() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("sender", "jane@example.com");
+        data.put("from", "\"Jane Doe\" <jane@example.com>");
+        data.put("recipient", "support@example.com");
+        data.put("subject", "hi");
+
+        InboundMessage m = new MailgunInboundParser().parse(data);
+
+        assertThat(m.fromName()).isEqualTo("Jane Doe");
+    }
+}

--- a/src/test/java/dev/escalated/services/email/inbound/PostmarkInboundParserTest.java
+++ b/src/test/java/dev/escalated/services/email/inbound/PostmarkInboundParserTest.java
@@ -1,0 +1,105 @@
+package dev.escalated.services.email.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PostmarkInboundParserTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String SAMPLE_PAYLOAD = """
+        {
+          "FromName": "Customer",
+          "MessageID": "22c74902-a0c1-4511-804f2-341342852c90",
+          "FromFull": {"Email": "customer@example.com", "Name": "Customer"},
+          "To": "support+abc@support.example.com",
+          "ToFull": [{"Email": "support+abc@support.example.com", "Name": ""}],
+          "OriginalRecipient": "support+abc@support.example.com",
+          "Subject": "[ESC-00042] Help",
+          "TextBody": "Plain body",
+          "HtmlBody": "<p>HTML body</p>",
+          "Headers": [
+            {"Name": "Message-ID", "Value": "<abc@mail.client>"},
+            {"Name": "In-Reply-To", "Value": "<ticket-42@support.example.com>"},
+            {"Name": "References", "Value": "<ticket-42@support.example.com>"}
+          ],
+          "Attachments": [
+            {"Name": "report.pdf", "Content": "aGVsbG8=",
+             "ContentType": "application/pdf", "ContentLength": 5}
+          ]
+        }
+        """;
+
+    private static Map<String, Object> parsePayload(String json) throws Exception {
+        return MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+    }
+
+    @Test
+    void parse_extractsCoreFields() throws Exception {
+        PostmarkInboundParser parser = new PostmarkInboundParser();
+
+        InboundMessage m = parser.parse(parsePayload(SAMPLE_PAYLOAD));
+
+        assertThat(m.fromEmail()).isEqualTo("customer@example.com");
+        assertThat(m.fromName()).isEqualTo("Customer");
+        assertThat(m.toEmail()).isEqualTo("support+abc@support.example.com");
+        assertThat(m.subject()).isEqualTo("[ESC-00042] Help");
+        assertThat(m.bodyText()).isEqualTo("Plain body");
+        assertThat(m.bodyHtml()).isEqualTo("<p>HTML body</p>");
+    }
+
+    @Test
+    void parse_extractsThreadingHeaders() throws Exception {
+        PostmarkInboundParser parser = new PostmarkInboundParser();
+
+        InboundMessage m = parser.parse(parsePayload(SAMPLE_PAYLOAD));
+
+        assertThat(m.inReplyTo()).isEqualTo("<ticket-42@support.example.com>");
+        assertThat(m.references()).isEqualTo("<ticket-42@support.example.com>");
+    }
+
+    @Test
+    void parse_extractsAttachments() throws Exception {
+        PostmarkInboundParser parser = new PostmarkInboundParser();
+
+        InboundMessage m = parser.parse(parsePayload(SAMPLE_PAYLOAD));
+
+        assertThat(m.attachments()).hasSize(1);
+        InboundAttachment a = m.attachments().get(0);
+        assertThat(a.name()).isEqualTo("report.pdf");
+        assertThat(a.contentType()).isEqualTo("application/pdf");
+        assertThat(a.sizeBytes()).isEqualTo(5L);
+        assertThat(new String(a.content())).isEqualTo("hello");
+    }
+
+    @Test
+    void parse_handlesMinimalPayload() throws Exception {
+        String json = """
+            {
+              "FromFull": {"Email": "a@b.com"},
+              "ToFull": [{"Email": "c@d.com"}],
+              "Subject": "minimal"
+            }
+            """;
+        PostmarkInboundParser parser = new PostmarkInboundParser();
+
+        InboundMessage m = parser.parse(parsePayload(json));
+
+        assertThat(m.fromEmail()).isEqualTo("a@b.com");
+        assertThat(m.fromName()).isNull();
+        assertThat(m.toEmail()).isEqualTo("c@d.com");
+        assertThat(m.subject()).isEqualTo("minimal");
+        assertThat(m.bodyText()).isNull();
+        assertThat(m.inReplyTo()).isNull();
+        assertThat(m.attachments()).isEmpty();
+    }
+
+    @Test
+    void name_isPostmark() {
+        assertThat(new PostmarkInboundParser().name()).isEqualTo("postmark");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last missing piece of the inbound webhook loop for Spring. Mirrors the .NET reference (escalated-dotnet #26).

## Flow (per inbound POST)

```
parser → InboundMessage
  → InboundEmailService.process(message)
    → InboundEmailRouter.resolveTicket
      - ticket found  → TicketService.addReply(...) → REPLIED_TO_EXISTING
      - none + noise  → SKIPPED (SNS confirmation, empty body+subject)
      - none + content→ TicketService.create(subject, body,
                                              guestName, guestEmail, MEDIUM)
                         → CREATED_NEW
```

## ProcessResult

Java `record` carrying:
- `outcome` (`REPLIED_TO_EXISTING` | `CREATED_NEW` | `SKIPPED`)
- `ticketId` / `replyId`
- `pendingAttachmentDownloads` — provider-hosted attachment URLs (Mailgun) that a follow-up worker fetches + persists out-of-band. Empty when all attachments came inline (Postmark).

## Controller response

Expanded from `{ status, ticketId }` to:

```json
{
  "outcome": "replied_to_existing",
  "ticketId": 42,
  "replyId": 99,
  "pendingAttachmentDownloads": [...]
}
```

## Dependencies

- **Stacked on #28** (`feat/mailgun-inbound-parser`). Merge order: #24 → #25 → #26 → #27 → #28 → this PR.

## Test plan

- [ ] Unit tests for `InboundEmailService.process` (reply / create / skip paths) — follow-up PR once the `@SpringBootTest` setup is added. .NET reference tests are at escalated-dotnet #26 and can be ported 1:1.
- [ ] CI green (won't trigger against stacked base until rebased)