### PR TITLE
feat(inbound): SESInboundParser (AWS SES via SNS HTTP subscription)

### DIFF
--- a/src/main/java/dev/escalated/services/email/inbound/SESInboundParser.java
+++ b/src/main/java/dev/escalated/services/email/inbound/SESInboundParser.java
@@ -1,0 +1,252 @@
+package dev.escalated.services.email.inbound;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses AWS SES inbound mail delivered via SNS HTTP subscription.
+ * SES receipt rules publish to an SNS topic; host apps subscribe via
+ * HTTP and SNS POSTs the envelope to the unified
+ * {@code /escalated/webhook/email/inbound?adapter=ses} webhook.
+ *
+ * <p>Handles two SNS envelope types:
+ * <ul>
+ *   <li>{@code Type=SubscriptionConfirmation} — throws
+ *     {@link SESSubscriptionConfirmationException} carrying the
+ *     {@code SubscribeURL} that the host must GET out-of-band to
+ *     activate the subscription.</li>
+ *   <li>{@code Type=Notification} — parses the JSON-encoded
+ *     {@code Message} field for {@code mail.commonHeaders}
+ *     (from/to/subject) and the {@code mail.headers} array
+ *     (Message-ID / In-Reply-To / References). Falls back to
+ *     {@code mail.headers} when {@code commonHeaders} doesn't
+ *     surface a threading field.</li>
+ * </ul>
+ *
+ * <p>Best-effort MIME body extraction from the base64-encoded
+ * {@code content} field when SES is configured with
+ * {@code action.type=SNS} / {@code encoding=BASE64}. Uses
+ * {@code jakarta.mail} — already transitively available via
+ * Spring Boot's mail starter. Handles single-part {@code text/plain} +
+ * {@code text/html} and {@code multipart/alternative} bodies.
+ */
+@Component
+public class SESInboundParser implements InboundEmailParser {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String name() {
+        return "ses";
+    }
+
+    @Override
+    public InboundMessage parse(Object rawPayload) {
+        JsonNode envelope = toJson(rawPayload);
+        String snsType = text(envelope, "Type");
+
+        switch (snsType) {
+            case "SubscriptionConfirmation" ->
+                throw new SESSubscriptionConfirmationException(
+                        text(envelope, "TopicArn"),
+                        text(envelope, "SubscribeURL"),
+                        text(envelope, "Token"));
+            case "Notification" -> { /* fall through */ }
+            default -> throw new IllegalArgumentException(
+                    "Unsupported SNS envelope type: " + snsType);
+        }
+
+        String messageJson = text(envelope, "Message");
+        if (messageJson.isEmpty()) {
+            throw new IllegalArgumentException("SES notification has no Message body");
+        }
+
+        JsonNode notification;
+        try {
+            notification = MAPPER.readTree(messageJson);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "SES notification Message is not valid JSON", e);
+        }
+
+        JsonNode mail = notification.path("mail");
+        JsonNode common = mail.path("commonHeaders");
+
+        FromAddress from = parseFirstAddressList(common.path("from"));
+        FromAddress to = parseFirstAddressList(common.path("to"));
+
+        String subject = text(common, "subject");
+        String messageId = text(common, "messageId");
+        String inReplyTo = text(common, "inReplyTo");
+        String references = text(common, "references");
+
+        Map<String, String> headers = extractHeaders(mail);
+        if (messageId.isEmpty()) {
+            messageId = headers.getOrDefault("Message-ID", "");
+        }
+        if (inReplyTo.isEmpty()) {
+            inReplyTo = headers.getOrDefault("In-Reply-To", "");
+        }
+        if (references.isEmpty()) {
+            references = headers.getOrDefault("References", "");
+        }
+
+        BodyParts body = extractBody(notification.path("content").asText(""));
+
+        return new InboundMessage(
+                from.email(),
+                from.name(),
+                to.email(),
+                subject,
+                body.text(),
+                body.html(),
+                messageId.isEmpty() ? null : messageId,
+                inReplyTo.isEmpty() ? null : inReplyTo,
+                references.isEmpty() ? null : references,
+                headers,
+                null
+        );
+    }
+
+    private static JsonNode toJson(Object rawPayload) {
+        try {
+            if (rawPayload instanceof JsonNode node) {
+                return node;
+            }
+            if (rawPayload instanceof String str) {
+                return MAPPER.readTree(str);
+            }
+            if (rawPayload instanceof byte[] bytes) {
+                return MAPPER.readTree(bytes);
+            }
+            return MAPPER.valueToTree(rawPayload);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unparseable SES payload", e);
+        }
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode v = node.path(field);
+        return v.isMissingNode() || v.isNull() ? "" : v.asText("");
+    }
+
+    private record FromAddress(String email, String name) {}
+
+    /**
+     * SES's {@code commonHeaders.from} / {@code .to} are arrays of
+     * RFC 5322 strings like {@code ["Alice <alice@example.com>"]}.
+     * Returns the first entry's email + display name.
+     */
+    private static FromAddress parseFirstAddressList(JsonNode arr) {
+        if (!arr.isArray() || arr.isEmpty()) {
+            return new FromAddress("", null);
+        }
+        String raw = arr.get(0).asText("").trim();
+        if (raw.isEmpty()) {
+            return new FromAddress("", null);
+        }
+        try {
+            InternetAddress addr = new InternetAddress(raw, false);
+            return new FromAddress(
+                    addr.getAddress() == null ? "" : addr.getAddress(),
+                    addr.getPersonal()
+            );
+        } catch (Exception e) {
+            return new FromAddress(raw, null);
+        }
+    }
+
+    private static Map<String, String> extractHeaders(JsonNode mail) {
+        Map<String, String> out = new LinkedHashMap<>();
+        JsonNode arr = mail.path("headers");
+        if (!arr.isArray()) {
+            return out;
+        }
+        for (JsonNode entry : arr) {
+            String name = text(entry, "name");
+            String value = text(entry, "value");
+            if (!name.isEmpty()) {
+                out.put(name, value);
+            }
+        }
+        return out;
+    }
+
+    private record BodyParts(String text, String html) {}
+
+    /**
+     * Decode the base64 {@code content} field and extract
+     * {@code text/plain} + {@code text/html} parts via jakarta.mail.
+     * Returns empty strings when content is absent, malformed, or
+     * the MIME parse fails — the router still resolves via
+     * threading metadata regardless.
+     */
+    private static BodyParts extractBody(String contentBase64) {
+        if (contentBase64.isEmpty()) {
+            return new BodyParts(null, null);
+        }
+        byte[] raw;
+        try {
+            raw = Base64.getDecoder().decode(contentBase64);
+        } catch (IllegalArgumentException e) {
+            return new BodyParts(null, null);
+        }
+
+        try {
+            Session session = Session.getDefaultInstance(new Properties(), null);
+            MimeMessage msg = new MimeMessage(session, new ByteArrayInputStream(raw));
+            Object content = msg.getContent();
+
+            if (content instanceof MimeMultipart multipart) {
+                return walkMultipart(multipart);
+            }
+            if (content instanceof String body) {
+                String contentType = msg.getContentType();
+                if (contentType != null && contentType.toLowerCase().startsWith("text/html")) {
+                    return new BodyParts(null, body);
+                }
+                return new BodyParts(body, null);
+            }
+            return new BodyParts(null, null);
+        } catch (Exception e) {
+            return new BodyParts(null, null);
+        }
+    }
+
+    private static BodyParts walkMultipart(MimeMultipart multipart) throws MessagingException {
+        String text = null;
+        String html = null;
+        for (int i = 0; i < multipart.getCount(); i++) {
+            var part = multipart.getBodyPart(i);
+            try {
+                Object partContent = part.getContent();
+                String partType = part.getContentType() == null ? "" : part.getContentType().toLowerCase();
+                if (partContent instanceof String s) {
+                    if (partType.startsWith("text/plain") && text == null) {
+                        text = s;
+                    } else if (partType.startsWith("text/html") && html == null) {
+                        html = s;
+                    }
+                } else if (partContent instanceof MimeMultipart nested) {
+                    BodyParts nestedParts = walkMultipart(nested);
+                    if (text == null) text = nestedParts.text();
+                    if (html == null) html = nestedParts.html();
+                }
+            } catch (Exception ignored) {
+                // continue to next part
+            }
+        }
+        return new BodyParts(text, html);
+    }
+}

--- a/src/main/java/dev/escalated/services/email/inbound/SESSubscriptionConfirmationException.java
+++ b/src/main/java/dev/escalated/services/email/inbound/SESSubscriptionConfirmationException.java
@@ -1,0 +1,35 @@
+package dev.escalated.services.email.inbound;
+
+/**
+ * Thrown by {@link SESInboundParser#parse} when the webhook receives
+ * an SNS subscription-confirmation envelope. The host app must fetch
+ * {@link #getSubscribeUrl} out-of-band to activate the subscription;
+ * the inbound controller catches this as a 202-Accepted sentinel so
+ * AWS stops retrying the confirmation POST.
+ */
+public class SESSubscriptionConfirmationException extends RuntimeException {
+
+    private final String topicArn;
+    private final String subscribeUrl;
+    private final String token;
+
+    public SESSubscriptionConfirmationException(String topicArn, String subscribeUrl, String token) {
+        super("SES subscription confirmation for topic " + topicArn
+                + "; GET " + subscribeUrl + " to confirm");
+        this.topicArn = topicArn;
+        this.subscribeUrl = subscribeUrl;
+        this.token = token;
+    }
+
+    public String getTopicArn() {
+        return topicArn;
+    }
+
+    public String getSubscribeUrl() {
+        return subscribeUrl;
+    }
+
+    public String getToken() {
+        return token;
+    }
+}

--- a/src/test/java/dev/escalated/services/email/inbound/SESInboundParserTest.java
+++ b/src/test/java/dev/escalated/services/email/inbound/SESInboundParserTest.java
@@ -1,0 +1,224 @@
+package dev.escalated.services.email.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SESInboundParserTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final SESInboundParser parser = new SESInboundParser();
+
+    @Test
+    void nameIsSes() {
+        assertThat(parser.name()).isEqualTo("ses");
+    }
+
+    @Test
+    void subscriptionConfirmationThrowsWithSubscribeUrl() {
+        var envelope = Map.of(
+                "Type", "SubscriptionConfirmation",
+                "TopicArn", "arn:aws:sns:us-east-1:123:escalated-inbound",
+                "SubscribeURL", "https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&Token=x",
+                "Token", "abc"
+        );
+
+        assertThatExceptionOfType(SESSubscriptionConfirmationException.class)
+                .isThrownBy(() -> parser.parse(envelope))
+                .matches(ex -> ex.getTopicArn().equals("arn:aws:sns:us-east-1:123:escalated-inbound"))
+                .matches(ex -> ex.getSubscribeUrl().contains("ConfirmSubscription"))
+                .matches(ex -> ex.getToken().equals("abc"));
+    }
+
+    @Test
+    void notificationExtractsThreadingMetadata() throws Exception {
+        var sesMessage = Map.of(
+                "notificationType", "Received",
+                "mail", Map.of(
+                        "source", "alice@example.com",
+                        "destination", List.of("support@example.com"),
+                        "headers", List.of(
+                                Map.of("name", "From", "value", "Alice <alice@example.com>"),
+                                Map.of("name", "To", "value", "support@example.com"),
+                                Map.of("name", "Subject", "value", "[ESC-42] Re: Help"),
+                                Map.of("name", "Message-ID", "value", "<external-xyz@mail.alice.com>"),
+                                Map.of("name", "In-Reply-To", "value", "<ticket-42@support.example.com>"),
+                                Map.of("name", "References", "value", "<ticket-42@support.example.com> <prev@mail.com>")
+                        ),
+                        "commonHeaders", Map.of(
+                                "from", List.of("Alice <alice@example.com>"),
+                                "to", List.of("support@example.com"),
+                                "subject", "[ESC-42] Re: Help"
+                        )
+                )
+        );
+        var envelope = Map.of(
+                "Type", "Notification",
+                "Message", MAPPER.writeValueAsString(sesMessage)
+        );
+
+        InboundMessage msg = parser.parse(envelope);
+
+        assertThat(msg.fromEmail()).isEqualTo("alice@example.com");
+        assertThat(msg.fromName()).isEqualTo("Alice");
+        assertThat(msg.toEmail()).isEqualTo("support@example.com");
+        assertThat(msg.subject()).isEqualTo("[ESC-42] Re: Help");
+        assertThat(msg.messageId()).isEqualTo("<external-xyz@mail.alice.com>");
+        assertThat(msg.inReplyTo()).isEqualTo("<ticket-42@support.example.com>");
+        assertThat(msg.references()).contains("ticket-42@support.example.com");
+        assertThat(msg.headers()).containsEntry("From", "Alice <alice@example.com>");
+    }
+
+    @Test
+    void notificationDecodesPlainTextBody() throws Exception {
+        String rawMime = "From: alice@example.com\r\n"
+                + "To: support@example.com\r\n"
+                + "Subject: Hi\r\n"
+                + "Content-Type: text/plain; charset=\"utf-8\"\r\n"
+                + "\r\n"
+                + "This is the plain text body.";
+        String contentB64 = Base64.getEncoder().encodeToString(rawMime.getBytes());
+
+        var envelope = Map.of(
+                "Type", "Notification",
+                "Message", MAPPER.writeValueAsString(Map.of(
+                        "mail", Map.of(
+                                "commonHeaders", Map.of(
+                                        "from", List.of("alice@example.com"),
+                                        "to", List.of("support@example.com"),
+                                        "subject", "Hi")),
+                        "content", contentB64
+                ))
+        );
+
+        InboundMessage msg = parser.parse(envelope);
+
+        assertThat(msg.bodyText()).contains("This is the plain text body.");
+    }
+
+    @Test
+    void notificationDecodesMultipartBody() throws Exception {
+        String boundary = "boundary-abc";
+        String rawMime = "From: alice@example.com\r\n"
+                + "To: support@example.com\r\n"
+                + "Subject: Hi\r\n"
+                + "Content-Type: multipart/alternative; boundary=\"" + boundary + "\"\r\n"
+                + "\r\n"
+                + "--" + boundary + "\r\n"
+                + "Content-Type: text/plain; charset=\"utf-8\"\r\n"
+                + "\r\n"
+                + "Plain body\r\n"
+                + "--" + boundary + "\r\n"
+                + "Content-Type: text/html; charset=\"utf-8\"\r\n"
+                + "\r\n"
+                + "<p>HTML body</p>\r\n"
+                + "--" + boundary + "--\r\n";
+        String contentB64 = Base64.getEncoder().encodeToString(rawMime.getBytes());
+
+        var envelope = Map.of(
+                "Type", "Notification",
+                "Message", MAPPER.writeValueAsString(Map.of(
+                        "mail", Map.of(
+                                "commonHeaders", Map.of(
+                                        "from", List.of("alice@example.com"),
+                                        "to", List.of("support@example.com"),
+                                        "subject", "Hi")),
+                        "content", contentB64
+                ))
+        );
+
+        InboundMessage msg = parser.parse(envelope);
+
+        assertThat(msg.bodyText()).contains("Plain body");
+        assertThat(msg.bodyHtml()).contains("<p>HTML body</p>");
+    }
+
+    @Test
+    void notificationMissingContentLeavesBodyEmpty() throws Exception {
+        var envelope = Map.of(
+                "Type", "Notification",
+                "Message", MAPPER.writeValueAsString(Map.of(
+                        "mail", Map.of(
+                                "commonHeaders", Map.of(
+                                        "from", List.of("alice@example.com"),
+                                        "to", List.of("support@example.com"),
+                                        "subject", "Hi"))
+                ))
+        );
+
+        InboundMessage msg = parser.parse(envelope);
+
+        assertThat(msg.bodyText()).isNull();
+        assertThat(msg.bodyHtml()).isNull();
+        assertThat(msg.fromEmail()).isEqualTo("alice@example.com");
+    }
+
+    @Test
+    void unknownEnvelopeTypeThrows() {
+        assertThatThrownBy(() -> parser.parse(Map.of("Type", "UnknownType")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported SNS envelope type");
+    }
+
+    @Test
+    void missingMessageFieldThrows() {
+        assertThatThrownBy(() -> parser.parse(Map.of("Type", "Notification")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no Message body");
+    }
+
+    @Test
+    void malformedMessageJsonThrows() {
+        assertThatThrownBy(() -> parser.parse(Map.of(
+                "Type", "Notification",
+                "Message", "not json at all")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void fallsBackToHeadersArrayForThreadingFields() throws Exception {
+        var envelope = Map.of(
+                "Type", "Notification",
+                "Message", MAPPER.writeValueAsString(Map.of(
+                        "mail", Map.of(
+                                "headers", List.of(
+                                        Map.of("name", "Message-ID", "value", "<fallback@mail.com>"),
+                                        Map.of("name", "In-Reply-To", "value", "<ticket-99@support.example.com>")
+                                ),
+                                "commonHeaders", Map.of(
+                                        "from", List.of("alice@example.com"),
+                                        "to", List.of("support@example.com"),
+                                        "subject", "Fallback"))
+                ))
+        );
+
+        InboundMessage msg = parser.parse(envelope);
+
+        assertThat(msg.messageId()).isEqualTo("<fallback@mail.com>");
+        assertThat(msg.inReplyTo()).isEqualTo("<ticket-99@support.example.com>");
+    }
+
+    @Test
+    void acceptsRawJsonString() throws Exception {
+        String bodyJson = MAPPER.writeValueAsString(Map.of(
+                "Type", "Notification",
+                "Message", MAPPER.writeValueAsString(Map.of(
+                        "mail", Map.of(
+                                "commonHeaders", Map.of(
+                                        "from", List.of("alice@example.com"),
+                                        "to", List.of("support@example.com"),
+                                        "subject", "Hi"))
+                ))
+        ));
+
+        InboundMessage msg = parser.parse(bodyJson);
+
+        assertThat(msg.fromEmail()).isEqualTo("alice@example.com");
+    }
+}


### PR DESCRIPTION
## Summary

Ports [escalated-go#36](https://github.com/escalated-dev/escalated-go/pull/36) + [escalated-dotnet#30](https://github.com/escalated-dev/escalated-dotnet/pull/30) to Spring Boot. AWS SES receipt rules publish to an SNS topic; host apps subscribe via HTTP and SNS POSTs the envelope to the unified \`/escalated/webhook/email/inbound?adapter=ses\` webhook.

## What's handled

1. **\`Type=SubscriptionConfirmation\`** — throws \`SESSubscriptionConfirmationException\` carrying \`topicArn\` + \`subscribeUrl\` + \`token\`.
2. **\`Type=Notification\`** — parses the JSON-encoded \`Message\` field. Extracts from/to/subject/messageId/inReplyTo/references via \`commonHeaders\`, falls back to raw \`headers\` array when \`commonHeaders\` doesn't surface a threading field.
3. **Best-effort MIME body extraction** from the base64 \`content\` field when SES is configured with \`action.type=SNS\` / \`encoding=BASE64\`. Uses \`jakarta.mail\` (already transitively available via \`spring-boot-starter-mail\`) to parse single-part \`text/plain\`, \`text/html\`, and \`multipart/alternative\` bodies.

## Tests

10 JUnit + AssertJ cases cover every branch including threading metadata extraction, plain + multipart body decoding, missing-content fallback, unknown envelope type, missing/malformed Message fields, headers-array threading fallback, and raw-JSON-string input.

## Stacked PR

Based on \`feat/attachment-downloader\` (#32). Merge order: #26 → #27 → #28 → #29 → #32 → this PR.