### PR TITLE
feat(workflow): delay action with deferred job queue

### DIFF
--- a/src/main/java/dev/escalated/models/DeferredWorkflowJob.java
+++ b/src/main/java/dev/escalated/models/DeferredWorkflowJob.java
@@ -1,0 +1,86 @@
+package dev.escalated.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/**
+ * Queue row for a paused workflow run — populated by the
+ * {@code delay} workflow action when execution hits a wait clause
+ * and consumed by
+ * {@link dev.escalated.services.WorkflowExecutorService#runDueDeferredJobs}
+ * to resume.
+ *
+ * <p>Rows are soft-terminal: the poller flips {@code status} to
+ * {@code done} (or {@code failed}) after running so they don't get
+ * re-picked up, and retains the row for audit.
+ */
+@Entity
+@Table(
+        name = "escalated_deferred_workflow_jobs",
+        indexes = @Index(name = "idx_deferred_status_runat", columnList = "status,run_at"))
+public class DeferredWorkflowJob extends BaseEntity {
+
+    @Column(name = "ticket_id", nullable = false)
+    private Long ticketId;
+
+    /**
+     * Remaining actions to run after the delay expires. Stored as a
+     * JSON array mirroring the shape of {@code Workflow.actions}.
+     */
+    @Column(name = "remaining_actions", columnDefinition = "JSON", nullable = false)
+    private String remainingActionsJson;
+
+    /** UTC timestamp after which the poller should pick this row up. */
+    @Column(name = "run_at", nullable = false)
+    private Instant runAt;
+
+    /** {@code pending} | {@code done} | {@code failed} — soft state machine. */
+    @Column(nullable = false, length = 16)
+    private String status = "pending";
+
+    @Column(name = "last_error", columnDefinition = "TEXT")
+    private String lastError;
+
+    public Long getTicketId() {
+        return ticketId;
+    }
+
+    public void setTicketId(Long ticketId) {
+        this.ticketId = ticketId;
+    }
+
+    public String getRemainingActionsJson() {
+        return remainingActionsJson;
+    }
+
+    public void setRemainingActionsJson(String remainingActionsJson) {
+        this.remainingActionsJson = remainingActionsJson;
+    }
+
+    public Instant getRunAt() {
+        return runAt;
+    }
+
+    public void setRunAt(Instant runAt) {
+        this.runAt = runAt;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getLastError() {
+        return lastError;
+    }
+
+    public void setLastError(String lastError) {
+        this.lastError = lastError;
+    }
+}

--- a/src/main/java/dev/escalated/repositories/DeferredWorkflowJobRepository.java
+++ b/src/main/java/dev/escalated/repositories/DeferredWorkflowJobRepository.java
@@ -1,0 +1,13 @@
+package dev.escalated.repositories;
+
+import dev.escalated.models.DeferredWorkflowJob;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeferredWorkflowJobRepository extends JpaRepository<DeferredWorkflowJob, Long> {
+
+    List<DeferredWorkflowJob> findByStatusAndRunAtLessThanEqual(String status, Instant runAt);
+}

--- a/src/main/java/dev/escalated/services/WorkflowExecutorService.java
+++ b/src/main/java/dev/escalated/services/WorkflowExecutorService.java
@@ -3,6 +3,7 @@ package dev.escalated.services;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.escalated.models.AgentProfile;
+import dev.escalated.models.DeferredWorkflowJob;
 import dev.escalated.models.Department;
 import dev.escalated.models.Reply;
 import dev.escalated.models.Tag;
@@ -10,16 +11,19 @@ import dev.escalated.models.Ticket;
 import dev.escalated.models.TicketPriority;
 import dev.escalated.models.TicketStatus;
 import dev.escalated.repositories.AgentProfileRepository;
+import dev.escalated.repositories.DeferredWorkflowJobRepository;
 import dev.escalated.repositories.DepartmentRepository;
 import dev.escalated.repositories.ReplyRepository;
 import dev.escalated.repositories.TagRepository;
 import dev.escalated.repositories.TicketRepository;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 /**
@@ -32,9 +36,14 @@ import org.springframework.stereotype.Service;
  *
  * <p>Action catalog: {@code change_priority}, {@code change_status},
  * {@code assign_agent}, {@code set_department}, {@code add_tag},
- * {@code remove_tag}, {@code add_note}, {@code insert_canned_reply}.
- * Mirrors the NestJS reference impl in
+ * {@code remove_tag}, {@code add_note}, {@code insert_canned_reply},
+ * {@code delay}. Mirrors the NestJS reference impl in
  * {@code escalated-nestjs/src/services/workflow-executor.service.ts}.
+ *
+ * <p>{@code delay} splits a run into two halves: everything before the
+ * delay runs inline, everything after is persisted as a
+ * {@link DeferredWorkflowJob} and picked up by
+ * {@link #runDueDeferredJobs()} once the wait expires.
  *
  * <p>Unknown or malformed actions are logged at {@code warn} and
  * skipped — one bad action never halts execution of the other
@@ -51,18 +60,21 @@ public class WorkflowExecutorService {
     private final AgentProfileRepository agentRepository;
     private final DepartmentRepository departmentRepository;
     private final ReplyRepository replyRepository;
+    private final DeferredWorkflowJobRepository deferredRepository;
 
     public WorkflowExecutorService(
             TicketRepository ticketRepository,
             TagRepository tagRepository,
             AgentProfileRepository agentRepository,
             DepartmentRepository departmentRepository,
-            ReplyRepository replyRepository) {
+            ReplyRepository replyRepository,
+            DeferredWorkflowJobRepository deferredRepository) {
         this.ticketRepository = ticketRepository;
         this.tagRepository = tagRepository;
         this.agentRepository = agentRepository;
         this.departmentRepository = departmentRepository;
         this.replyRepository = replyRepository;
+        this.deferredRepository = deferredRepository;
     }
 
     /**
@@ -75,7 +87,20 @@ public class WorkflowExecutorService {
      */
     public List<Map<String, Object>> execute(Ticket ticket, String actionsJson) {
         List<Map<String, Object>> actions = parseActions(actionsJson);
-        for (Map<String, Object> action : actions) {
+        executeParsed(ticket, actions);
+        return actions;
+    }
+
+    private void executeParsed(Ticket ticket, List<Map<String, Object>> actions) {
+        for (int i = 0; i < actions.size(); i++) {
+            Map<String, Object> action = actions.get(i);
+            String type = String.valueOf(action.getOrDefault("type", ""));
+            if ("delay".equals(type)) {
+                String value = action.get("value") == null ? "" : String.valueOf(action.get("value"));
+                List<Map<String, Object>> remaining = actions.subList(i + 1, actions.size());
+                scheduleDelay(ticket, value, remaining);
+                return;
+            }
             try {
                 dispatch(ticket, action);
             } catch (RuntimeException ex) {
@@ -83,7 +108,6 @@ public class WorkflowExecutorService {
                         action.get("type"), ticket.getId(), ex.getMessage());
             }
         }
-        return actions;
     }
 
     private List<Map<String, Object>> parseActions(String actionsJson) {
@@ -221,6 +245,74 @@ public class WorkflowExecutorService {
         reply.setAuthorType("system");
         reply.setInternal(false);
         replyRepository.save(reply);
+    }
+
+    private void scheduleDelay(Ticket ticket, String value, List<Map<String, Object>> remaining) {
+        Long seconds = parseLong(value);
+        if (seconds == null || seconds <= 0) {
+            log.warn(
+                    "[WorkflowExecutor] delay: invalid seconds value '{}', skipping remaining actions",
+                    value);
+            return;
+        }
+        String remainingJson;
+        try {
+            remainingJson = MAPPER.writeValueAsString(remaining);
+        } catch (Exception ex) {
+            log.warn(
+                    "[WorkflowExecutor] delay: failed to serialize remaining actions: {}",
+                    ex.getMessage());
+            return;
+        }
+        DeferredWorkflowJob job = new DeferredWorkflowJob();
+        job.setTicketId(ticket.getId());
+        job.setRemainingActionsJson(remainingJson);
+        job.setRunAt(Instant.now().plusSeconds(seconds));
+        job.setStatus("pending");
+        deferredRepository.save(job);
+    }
+
+    /**
+     * Poll for deferred jobs whose wait has elapsed and resume their
+     * remaining actions. Flips status to {@code done} on success,
+     * {@code failed} (with {@code lastError} populated) on exception,
+     * so rows are audit-retained and never re-picked up.
+     *
+     * <p>Fires on the same 60-second cadence as the NestJS reference and
+     * the existing snooze + SLA schedulers.
+     */
+    @Scheduled(fixedDelayString = "${escalated.workflow.deferred-check-interval-seconds:60}000")
+    public void runDueDeferredJobs() {
+        List<DeferredWorkflowJob> due;
+        try {
+            due = deferredRepository.findByStatusAndRunAtLessThanEqual("pending", Instant.now());
+        } catch (RuntimeException ex) {
+            log.error("[WorkflowExecutor] failed to query deferred jobs: {}", ex.getMessage());
+            return;
+        }
+        for (DeferredWorkflowJob job : due) {
+            try {
+                Optional<Ticket> ticket = ticketRepository.findById(job.getTicketId());
+                if (ticket.isEmpty()) {
+                    job.setStatus("failed");
+                    job.setLastError("Ticket #" + job.getTicketId() + " not found");
+                    deferredRepository.save(job);
+                    continue;
+                }
+                List<Map<String, Object>> remaining = parseActions(job.getRemainingActionsJson());
+                executeParsed(ticket.get(), remaining);
+                job.setStatus("done");
+                deferredRepository.save(job);
+            } catch (RuntimeException ex) {
+                log.error(
+                        "[WorkflowExecutor] deferred job #{} failed: {}",
+                        job.getId(),
+                        ex.getMessage());
+                job.setStatus("failed");
+                job.setLastError(ex.getMessage() == null ? "unknown error" : ex.getMessage());
+                deferredRepository.save(job);
+            }
+        }
     }
 
     private static Map<String, String> ticketToMap(Ticket ticket) {

--- a/src/test/java/dev/escalated/services/WorkflowExecutorServiceTest.java
+++ b/src/test/java/dev/escalated/services/WorkflowExecutorServiceTest.java
@@ -3,11 +3,13 @@ package dev.escalated.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import dev.escalated.models.AgentProfile;
+import dev.escalated.models.DeferredWorkflowJob;
 import dev.escalated.models.Department;
 import dev.escalated.models.Reply;
 import dev.escalated.models.Tag;
@@ -15,11 +17,14 @@ import dev.escalated.models.Ticket;
 import dev.escalated.models.TicketPriority;
 import dev.escalated.models.TicketStatus;
 import dev.escalated.repositories.AgentProfileRepository;
+import dev.escalated.repositories.DeferredWorkflowJobRepository;
 import dev.escalated.repositories.DepartmentRepository;
 import dev.escalated.repositories.ReplyRepository;
 import dev.escalated.repositories.TagRepository;
 import dev.escalated.repositories.TicketRepository;
+import java.time.Instant;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +47,7 @@ class WorkflowExecutorServiceTest {
     @Mock private AgentProfileRepository agentRepository;
     @Mock private DepartmentRepository departmentRepository;
     @Mock private ReplyRepository replyRepository;
+    @Mock private DeferredWorkflowJobRepository deferredRepository;
 
     private WorkflowExecutorService executor;
 
@@ -49,7 +55,7 @@ class WorkflowExecutorServiceTest {
     void setUp() {
         executor = new WorkflowExecutorService(
                 ticketRepository, tagRepository, agentRepository,
-                departmentRepository, replyRepository);
+                departmentRepository, replyRepository, deferredRepository);
     }
 
     private Ticket newTicket() {
@@ -294,5 +300,86 @@ class WorkflowExecutorServiceTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(0)).containsEntry("type", "change_priority");
         assertThat(result.get(1)).containsEntry("type", "add_note");
+    }
+
+    // --- delay action ---
+
+    @Test
+    void execute_delay_pausesAndPersistsRemainingActions() {
+        Ticket ticket = newTicket();
+        long before = System.currentTimeMillis();
+
+        executor.execute(ticket,
+                "[{\"type\":\"change_priority\",\"value\":\"high\"},"
+                + "{\"type\":\"delay\",\"value\":\"60\"},"
+                + "{\"type\":\"add_note\",\"value\":\"after wait\"}]");
+
+        // pre-delay action ran
+        assertThat(ticket.getPriority()).isEqualTo(TicketPriority.HIGH);
+        // post-delay action did NOT run
+        verify(replyRepository, never()).save(any());
+
+        ArgumentCaptor<DeferredWorkflowJob> captor = ArgumentCaptor.forClass(DeferredWorkflowJob.class);
+        verify(deferredRepository).save(captor.capture());
+        DeferredWorkflowJob saved = captor.getValue();
+        assertThat(saved.getTicketId()).isEqualTo(1L);
+        assertThat(saved.getStatus()).isEqualTo("pending");
+        assertThat(saved.getRemainingActionsJson()).contains("\"add_note\"").contains("\"after wait\"");
+        assertThat(saved.getRunAt().toEpochMilli())
+                .isGreaterThanOrEqualTo(before + 60_000 - 500);
+    }
+
+    @Test
+    void execute_delay_invalidValueSkipsRemainingActions() {
+        Ticket ticket = newTicket();
+
+        executor.execute(ticket,
+                "[{\"type\":\"delay\",\"value\":\"nonsense\"},"
+                + "{\"type\":\"change_priority\",\"value\":\"urgent\"}]");
+
+        verify(deferredRepository, never()).save(any());
+        // priority should remain LOW from newTicket() — post-delay action must not have run
+        assertThat(ticket.getPriority()).isEqualTo(TicketPriority.LOW);
+    }
+
+    @Test
+    void runDueDeferredJobs_resumesAndMarksDone() {
+        DeferredWorkflowJob job = new DeferredWorkflowJob();
+        job.setId(99L);
+        job.setTicketId(1L);
+        job.setRemainingActionsJson("[{\"type\":\"change_priority\",\"value\":\"urgent\"}]");
+        job.setRunAt(Instant.now().minusSeconds(10));
+        job.setStatus("pending");
+
+        Ticket ticket = newTicket();
+        when(deferredRepository.findByStatusAndRunAtLessThanEqual(eq("pending"), any()))
+                .thenReturn(List.of(job));
+        when(ticketRepository.findById(1L)).thenReturn(Optional.of(ticket));
+
+        executor.runDueDeferredJobs();
+
+        assertThat(ticket.getPriority()).isEqualTo(TicketPriority.URGENT);
+        assertThat(job.getStatus()).isEqualTo("done");
+        verify(deferredRepository).save(job);
+    }
+
+    @Test
+    void runDueDeferredJobs_marksFailedWhenTicketMissing() {
+        DeferredWorkflowJob job = new DeferredWorkflowJob();
+        job.setId(99L);
+        job.setTicketId(404L);
+        job.setRemainingActionsJson("[]");
+        job.setRunAt(Instant.now().minusSeconds(10));
+        job.setStatus("pending");
+
+        when(deferredRepository.findByStatusAndRunAtLessThanEqual(eq("pending"), any()))
+                .thenReturn(List.of(job));
+        when(ticketRepository.findById(404L)).thenReturn(Optional.empty());
+
+        executor.runDueDeferredJobs();
+
+        assertThat(job.getStatus()).isEqualTo("failed");
+        assertThat(job.getLastError()).contains("404");
+        verify(deferredRepository).save(job);
     }
 }


### PR DESCRIPTION
## Summary

Adds the \`delay\` workflow action as a ninth entry in the catalog. Splits execution around a wait clause: actions before the delay run inline, remaining actions are persisted as a \`DeferredWorkflowJob\` row with \`runAt = now + N seconds\`. A \`@Scheduled\` poller on \`WorkflowExecutorService\` (60s cadence, matching SnoozeScheduler) picks up due pending jobs, rehydrates the ticket, resumes the saved action sequence, and flips status to \`done\` / \`failed\`. Rows are audit-retained.

## What's added

- \`DeferredWorkflowJob\` entity — \`(ticket_id, remaining_actions JSON, run_at, status, last_error)\` with a composite \`(status, run_at)\` index for efficient polling
- \`DeferredWorkflowJobRepository\` — single derived query \`findByStatusAndRunAtLessThanEqual\`
- New branch in \`WorkflowExecutorService.execute\` — when \`type: \"delay\"\` is seen, serialize the \`actions[i+1:]\` suffix + save + return
- \`@Scheduled\` \`runDueDeferredJobs()\` polling method on the same executor (mirrors how the NestJS reference keeps the poller co-located with the executor rather than factoring out a separate scheduler component)
- 4 new unit tests: pre-delay action runs + post-delay doesn't + DeferredWorkflowJob persisted correctly; invalid seconds skips cleanly; poller resumes + marks done; poller handles missing ticket with \`failed\` status

## Why

Ports [escalated-nestjs#26](https://github.com/escalated-dev/escalated-nestjs/pull/26) to the Spring plugin. The other eight workflow actions already in \`feat/workflow-executor\` (\`change_priority\`, \`change_status\`, \`assign_agent\`, \`set_department\`, \`add_tag\`, \`remove_tag\`, \`add_note\`, \`insert_canned_reply\`) now have parity with the NestJS reference; \`delay\` was the last missing entry.

The H2 test DB uses \`ddl-auto=create-drop\`, so the new entity's schema is auto-generated in tests without a migration. A production Flyway migration can follow as a separate PR once this pattern is accepted.

## Base / Stacking

Stacked on \`feat/workflow-executor\` (PR #21). CI won't exercise this branch until that base merges and this rebases onto \`main\`.

## Test plan
- [ ] CI runs \`./gradlew test\` — 4 new + 22 existing WorkflowExecutorServiceTest cases should pass
- [ ] Reviewer: confirm 60s polling cadence is acceptable (if you want a faster wake-up, override \`escalated.workflow.deferred-check-interval-seconds\` in \`application.properties\`)
- [ ] Reviewer: sanity-check the \`subList\` usage in \`executeParsed\` — it creates a view, not a copy, which is fine here because Jackson only iterates once before the return