### PR TITLE
feat(admin): public-ticket guest policy settings endpoints (Task 6.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Flyway migrations are included and run automatically. The migration creates all 
 | GET/POST | `/roles` | CRUD roles |
 | GET/POST | `/custom-fields` | CRUD custom fields |
 | GET/POST | `/settings` | Manage settings |
+| GET/PUT | `/settings/public-tickets` | Runtime guest-policy mode (unassigned / guest_user / prompt_signup). See [docs.escalated.dev/public-tickets](https://docs.escalated.dev/public-tickets). |
 | GET | `/audit-logs` | View audit logs |
 | POST | `/import/tickets` | Import tickets |
 | GET/POST | `/kb/categories` | Manage KB categories |

--- a/src/main/java/dev/escalated/controllers/admin/AdminSettingsController.java
+++ b/src/main/java/dev/escalated/controllers/admin/AdminSettingsController.java
@@ -1,14 +1,18 @@
 package dev.escalated.controllers.admin;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.escalated.models.EscalatedSettings;
 import dev.escalated.services.SettingsService;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,6 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/escalated/api/admin/settings")
 public class AdminSettingsController {
+
+    private static final String PUBLIC_TICKETS_GROUP = "public_tickets";
+    private static final String KEY_MODE = "guest_policy_mode";
+    private static final String KEY_USER_ID = "guest_policy_user_id";
+    private static final String KEY_SIGNUP_URL = "guest_policy_signup_url_template";
+    private static final Set<String> VALID_MODES = Set.of("unassigned", "guest_user", "prompt_signup");
 
     private final SettingsService settingsService;
 
@@ -42,5 +52,80 @@ public class AdminSettingsController {
     public ResponseEntity<Void> destroy(@PathVariable String key) {
         settingsService.delete(key);
         return ResponseEntity.noContent().build();
+    }
+
+    // --- Public-ticket guest policy ---
+    //
+    // Three keys back the policy that decides the identity a public
+    // submission is attributed to:
+    //   - guest_policy_mode              ∈ { unassigned, guest_user, prompt_signup }
+    //   - guest_policy_user_id           required when mode = guest_user
+    //   - guest_policy_signup_url_template  optional when mode = prompt_signup
+    // Consumers (widget controller, inbound router) read via
+    // SettingsService#getOrDefault so admins can switch modes at runtime
+    // without a redeploy. Mirrors the Symfony + .NET + Go ports.
+
+    @GetMapping("/public-tickets")
+    public ResponseEntity<Map<String, Object>> getPublicTicketsSettings() {
+        return ResponseEntity.ok(loadPublicTicketsSettings());
+    }
+
+    @PutMapping("/public-tickets")
+    public ResponseEntity<Map<String, Object>> updatePublicTicketsSettings(
+            @RequestBody PublicTicketsSettingsRequest request) {
+        String mode = VALID_MODES.contains(request.guestPolicyMode()) ? request.guestPolicyMode() : "unassigned";
+        settingsService.set(KEY_MODE, mode, PUBLIC_TICKETS_GROUP);
+
+        // Clear mode-specific fields we don't need so stale values
+        // can't leak back into behavior after a mode switch.
+        if ("guest_user".equals(mode) && request.guestPolicyUserId() != null && request.guestPolicyUserId() > 0) {
+            settingsService.set(KEY_USER_ID, request.guestPolicyUserId().toString(), PUBLIC_TICKETS_GROUP);
+        } else {
+            settingsService.set(KEY_USER_ID, "", PUBLIC_TICKETS_GROUP);
+        }
+
+        if ("prompt_signup".equals(mode)) {
+            String template = request.guestPolicySignupUrlTemplate() == null
+                    ? ""
+                    : request.guestPolicySignupUrlTemplate().trim();
+            if (template.length() > 500) {
+                template = template.substring(0, 500);
+            }
+            settingsService.set(KEY_SIGNUP_URL, template, PUBLIC_TICKETS_GROUP);
+        } else {
+            settingsService.set(KEY_SIGNUP_URL, "", PUBLIC_TICKETS_GROUP);
+        }
+
+        return ResponseEntity.ok(loadPublicTicketsSettings());
+    }
+
+    private Map<String, Object> loadPublicTicketsSettings() {
+        String mode = settingsService.getOrDefault(KEY_MODE, "unassigned");
+        String userIdRaw = settingsService.getOrDefault(KEY_USER_ID, "");
+        String template = settingsService.getOrDefault(KEY_SIGNUP_URL, "");
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("guest_policy_mode", mode);
+        payload.put("guest_policy_user_id", parseOptionalPositive(userIdRaw));
+        payload.put("guest_policy_signup_url_template", template);
+        return payload;
+    }
+
+    private static Long parseOptionalPositive(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            long n = Long.parseLong(raw.trim());
+            return n > 0 ? n : null;
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    public record PublicTicketsSettingsRequest(
+            @JsonProperty("guest_policy_mode") String guestPolicyMode,
+            @JsonProperty("guest_policy_user_id") Long guestPolicyUserId,
+            @JsonProperty("guest_policy_signup_url_template") String guestPolicySignupUrlTemplate) {
     }
 }

--- a/src/test/java/dev/escalated/controllers/AdminPublicTicketsSettingsControllerTest.java
+++ b/src/test/java/dev/escalated/controllers/AdminPublicTicketsSettingsControllerTest.java
@@ -1,0 +1,192 @@
+package dev.escalated.controllers;
+
+import dev.escalated.controllers.admin.AdminSettingsController;
+import dev.escalated.security.ApiTokenAuthenticationFilter;
+import dev.escalated.services.SettingsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests for the two public-tickets settings endpoints on
+ * {@link AdminSettingsController}. The controller delegates all
+ * persistence to {@link SettingsService}; these tests use a
+ * map-backed fake so we exercise the validation + mode-switch-cleanup
+ * semantics end-to-end without booting the DB.
+ */
+@WebMvcTest(AdminSettingsController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AdminPublicTicketsSettingsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ApiTokenAuthenticationFilter apiTokenFilter;
+
+    @MockBean
+    private SettingsService settingsService;
+
+    private Map<String, String> store;
+
+    @BeforeEach
+    void setUp() {
+        store = new HashMap<>();
+        // Fake SettingsService by routing get/set through the map.
+        when(settingsService.getOrDefault(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString()))
+                .thenAnswer(inv -> store.getOrDefault(inv.getArgument(0, String.class),
+                        inv.getArgument(1, String.class)));
+        org.mockito.Mockito.doAnswer(inv -> {
+            store.put(inv.getArgument(0, String.class),
+                    inv.getArgument(1, String.class));
+            return null;
+        }).when(settingsService)
+                .set(org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void get_defaultsToUnassigned_whenNoSettingsWritten() throws Exception {
+        mockMvc.perform(get("/escalated/api/admin/settings/public-tickets"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.guest_policy_mode").value("unassigned"))
+                .andExpect(jsonPath("$.guest_policy_user_id").isEmpty())
+                .andExpect(jsonPath("$.guest_policy_signup_url_template").value(""));
+    }
+
+    @Test
+    void put_persistsGuestUserMode_andClearsTemplate() throws Exception {
+        String body = """
+            {"guest_policy_mode":"guest_user","guest_policy_user_id":42,
+             "guest_policy_signup_url_template":"https://ignored.example"}
+            """;
+
+        mockMvc.perform(put("/escalated/api/admin/settings/public-tickets")
+                        .contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.guest_policy_mode").value("guest_user"))
+                .andExpect(jsonPath("$.guest_policy_user_id").value(42))
+                .andExpect(jsonPath("$.guest_policy_signup_url_template").value(""));
+
+        // Template must be explicitly cleared on non-prompt_signup mode.
+        verify(settingsService).set(eq("guest_policy_signup_url_template"), eq(""),
+                eq("public_tickets"));
+    }
+
+    @Test
+    void put_persistsPromptSignupMode_andClearsUserId() throws Exception {
+        String body = """
+            {"guest_policy_mode":"prompt_signup","guest_policy_user_id":99,
+             "guest_policy_signup_url_template":"https://example.com/join?t={{token}}"}
+            """;
+
+        mockMvc.perform(put("/escalated/api/admin/settings/public-tickets")
+                        .contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.guest_policy_mode").value("prompt_signup"))
+                .andExpect(jsonPath("$.guest_policy_user_id").isEmpty())
+                .andExpect(jsonPath("$.guest_policy_signup_url_template")
+                        .value("https://example.com/join?t={{token}}"));
+
+        verify(settingsService).set(eq("guest_policy_user_id"), eq(""), eq("public_tickets"));
+    }
+
+    @Test
+    void put_unknownMode_coercesToUnassigned() throws Exception {
+        String body = """
+            {"guest_policy_mode":"bogus","guest_policy_user_id":5,
+             "guest_policy_signup_url_template":"ignored"}
+            """;
+
+        mockMvc.perform(put("/escalated/api/admin/settings/public-tickets")
+                        .contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.guest_policy_mode").value("unassigned"))
+                .andExpect(jsonPath("$.guest_policy_user_id").isEmpty())
+                .andExpect(jsonPath("$.guest_policy_signup_url_template").value(""));
+    }
+
+    @Test
+    void put_truncatesLongSignupTemplate_at500Chars() throws Exception {
+        String longTemplate = "x".repeat(1000);
+        String body = "{\"guest_policy_mode\":\"prompt_signup\","
+                + "\"guest_policy_signup_url_template\":\"" + longTemplate + "\"}";
+
+        mockMvc.perform(put("/escalated/api/admin/settings/public-tickets")
+                .contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(settingsService).set(eq("guest_policy_signup_url_template"), captor.capture(),
+                eq("public_tickets"));
+        // The captured value should be exactly 500 chars (truncated).
+        org.junit.jupiter.api.Assertions.assertEquals(500, captor.getValue().length());
+    }
+
+    @Test
+    void put_zeroUserId_clearsField() throws Exception {
+        String body = "{\"guest_policy_mode\":\"guest_user\",\"guest_policy_user_id\":0}";
+
+        mockMvc.perform(put("/escalated/api/admin/settings/public-tickets")
+                        .contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.guest_policy_user_id").isEmpty());
+
+        verify(settingsService).set(eq("guest_policy_user_id"), eq(""), eq("public_tickets"));
+    }
+
+    @Test
+    void put_modeSwitch_clearsStaleFields() throws Exception {
+        // First, set guest_user with a user id.
+        String body1 = "{\"guest_policy_mode\":\"guest_user\",\"guest_policy_user_id\":42}";
+        mockMvc.perform(put("/escalated/api/admin/settings/public-tickets")
+                        .contentType(MediaType.APPLICATION_JSON).content(body1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.guest_policy_user_id").value(42));
+
+        // Now switch to unassigned — user_id must clear.
+        String body2 = "{\"guest_policy_mode\":\"unassigned\"}";
+        mockMvc.perform(put("/escalated/api/admin/settings/public-tickets")
+                        .contentType(MediaType.APPLICATION_JSON).content(body2))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.guest_policy_mode").value("unassigned"))
+                .andExpect(jsonPath("$.guest_policy_user_id").isEmpty());
+    }
+
+    @Test
+    void get_returnsLatestAfterMultipleWrites() throws Exception {
+        mockMvc.perform(put("/escalated/api/admin/settings/public-tickets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"guest_policy_mode\":\"guest_user\",\"guest_policy_user_id\":7}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(put("/escalated/api/admin/settings/public-tickets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"guest_policy_mode\":\"guest_user\",\"guest_policy_user_id\":15}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/escalated/api/admin/settings/public-tickets"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.guest_policy_mode").value("guest_user"))
+                .andExpect(jsonPath("$.guest_policy_user_id").value(15));
+    }
+}


### PR DESCRIPTION
## Summary

Adds \`GET\` + \`PUT /escalated/api/admin/settings/public-tickets\` so admins can switch the public-ticket guest-policy mode at runtime via the shared \`Admin/Settings/PublicTickets.vue\` page. Closes Plan Task 6.3 for the Spring greenfield host adapter.

Spring already had \`SettingsService\` + \`EscalatedSettings\` + repository from an earlier PR, so this is a pure controller-layer add — no migration or schema changes needed.

## What's added

Three guest-policy keys under the \`public_tickets\` settings group:
- \`guest_policy_mode\` ∈ \`unassigned | guest_user | prompt_signup\`
- \`guest_policy_user_id\` — required when mode = \`guest_user\`
- \`guest_policy_signup_url_template\` — optional when mode = \`prompt_signup\` (≤500 chars)

Handler semantics match the rest of the rollout (Symfony / .NET / Go):
- Unknown mode values coerce to \`unassigned\` (never 500s on bad input)
- Mode switch clears fields that don't apply to the new mode
- Zero / negative / non-numeric user_id surfaces as JSON \`null\` on GET
- Signup URL templates are trimmed + truncated to 500 chars

\`PublicTicketsSettingsRequest\` record uses \`@JsonProperty\` snake_case attributes so the wire format matches what the shared Vue page sends.

## Test plan

- [ ] CI: \`./gradlew test\` — 8 new MockMvc tests:
    - defaults-when-empty
    - \`guest_user\` + \`prompt_signup\` happy paths (with cross-mode cleanup)
    - unknown-mode coercion
    - 500-char truncation
    - zero user_id handling
    - mode-switch cleanup edge case
    - multi-write read-after-write consistency
- [ ] Couldn't run \`./gradlew test\` locally (no Java toolchain on this box); relies on CI
- [ ] Reviewer: sanity-check the \`@JsonProperty\` on record components pattern works with the project's Jackson version (standard Java 14+ record pattern; should be fine with Spring Boot 3's Jackson 2.15+, but worth a spot-check if this is the first record-based request DTO in the codebase)

## Follow-ups

- Phoenix still needs equivalent endpoints for Task 6.3 parity — similar lift to the Go port (Ecto schema + migration + service + controller).