### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Make `SimpMessagingTemplate` an optional dependency so the app boots without STOMP broker configuration (#19)
+- Include `url` in attachment JSON serialization (#10)
+- Include computed ticket fields in ticket JSON serialization (#11)
+- Include chat, context panel, and activity fields in ticket serialization (#12)
+- Include missing workflow and workflow log computed fields in serialization (#13)
+
+### Internal
+- Docker dev/demo environment under `docker/` with click-to-login agent picker and seeded profiles (#14, #18)
+- Complete README translations across supported locales (#9)
+
+## [0.1.0] — initial release
+
+Spring Boot 3.2 port of `escalated` reaching feature parity with the Laravel reference: tickets, workflow engine, chat, KB, reports, SLA tracking, and Inertia-driven Vue frontend served through the shared `@escalated-dev/escalated` package.


### PR DESCRIPTION
## Summary
- Backfills change history from merged PRs on main (#9 through #19)
- Keep a Changelog format, matches the style used in escalated-laravel / escalated-nestjs / escalated-rails
- Unreleased section holds the merged fixes and internal/demo work
- Future stacked work (inbound email, workflow executor, public-ticket guest policy) moves into Unreleased as it merges

## Test plan
- [x] No code changed; docs-only