### PR TITLE
feat(email): wire MessageIdUtil into EmailService outbound headers

### DIFF
--- a/src/main/java/dev/escalated/config/EscalatedProperties.java
+++ b/src/main/java/dev/escalated/config/EscalatedProperties.java
@@ -15,6 +15,7 @@ public class EscalatedProperties {
     private WebhookProperties webhook = new WebhookProperties();
     private WidgetProperties widget = new WidgetProperties();
     private GuestAccessProperties guestAccess = new GuestAccessProperties();
+    private EmailProperties email = new EmailProperties();
 
     public boolean isEnabled() {
         return enabled;
@@ -94,6 +95,14 @@ public class EscalatedProperties {
 
     public void setGuestAccess(GuestAccessProperties guestAccess) {
         this.guestAccess = guestAccess;
+    }
+
+    public EmailProperties getEmail() {
+        return email;
+    }
+
+    public void setEmail(EmailProperties email) {
+        this.email = email;
     }
 
     public static class KnowledgeBaseProperties {
@@ -189,6 +198,34 @@ public class EscalatedProperties {
 
         public void setEnabled(boolean enabled) {
             this.enabled = enabled;
+        }
+    }
+
+    /**
+     * Outbound + inbound email config. {@code domain} is used for the
+     * right-hand side of RFC 5322 Message-IDs and signed Reply-To
+     * addresses. {@code inboundSecret} is the HMAC key used to sign
+     * Reply-To addresses so the inbound provider webhook can verify
+     * a ticket id without trusting the mail client's threading headers.
+     */
+    public static class EmailProperties {
+        private String domain = "localhost";
+        private String inboundSecret = "";
+
+        public String getDomain() {
+            return domain;
+        }
+
+        public void setDomain(String domain) {
+            this.domain = domain;
+        }
+
+        public String getInboundSecret() {
+            return inboundSecret;
+        }
+
+        public void setInboundSecret(String inboundSecret) {
+            this.inboundSecret = inboundSecret;
         }
     }
 }

--- a/src/main/java/dev/escalated/services/EmailService.java
+++ b/src/main/java/dev/escalated/services/EmailService.java
@@ -1,7 +1,9 @@
 package dev.escalated.services;
 
+import dev.escalated.config.EscalatedProperties;
 import dev.escalated.models.Reply;
 import dev.escalated.models.Ticket;
+import dev.escalated.services.email.MessageIdUtil;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.slf4j.Logger;
@@ -19,10 +21,15 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
     private final TemplateEngine templateEngine;
+    private final EscalatedProperties properties;
 
-    public EmailService(JavaMailSender mailSender, TemplateEngine templateEngine) {
+    public EmailService(
+            JavaMailSender mailSender,
+            TemplateEngine templateEngine,
+            EscalatedProperties properties) {
         this.mailSender = mailSender;
         this.templateEngine = templateEngine;
+        this.properties = properties;
     }
 
     public void sendTicketCreatedNotification(Ticket ticket) {
@@ -31,8 +38,10 @@ public class EmailService {
         context.setVariable("ticketUrl", "/escalated/tickets/" + ticket.getId());
 
         String htmlContent = templateEngine.process("email/ticket-created", context);
+        String messageId = MessageIdUtil.buildMessageId(
+                ticket.getId(), null, emailDomain());
         sendEmail(ticket.getRequesterEmail(), "Ticket Created: " + ticket.getSubject(),
-                htmlContent, ticket.getEmailMessageId());
+                htmlContent, messageId, null, ticket.getId());
     }
 
     public void sendReplyNotification(Ticket ticket, Reply reply) {
@@ -46,7 +55,14 @@ public class EmailService {
                 : (ticket.getAssignedAgent() != null ? ticket.getAssignedAgent().getEmail() : null);
 
         if (recipient != null) {
-            sendEmail(recipient, "Re: " + ticket.getSubject(), htmlContent, reply.getEmailMessageId());
+            // Reply Message-ID includes reply id; References points back
+            // to the ticket-root Message-ID so clients thread correctly.
+            String replyMessageId = MessageIdUtil.buildMessageId(
+                    ticket.getId(), reply.getId(), emailDomain());
+            String rootMessageId = MessageIdUtil.buildMessageId(
+                    ticket.getId(), null, emailDomain());
+            sendEmail(recipient, "Re: " + ticket.getSubject(), htmlContent,
+                    replyMessageId, rootMessageId, ticket.getId());
         }
     }
 
@@ -56,10 +72,20 @@ public class EmailService {
         context.setVariable("surveyUrl", surveyUrl);
 
         String htmlContent = templateEngine.process("email/satisfaction-survey", context);
-        sendEmail(ticket.getRequesterEmail(), "How was your experience?", htmlContent, null);
+        sendEmail(ticket.getRequesterEmail(), "How was your experience?",
+                htmlContent, null, null, ticket.getId());
     }
 
-    private void sendEmail(String to, String subject, String htmlContent, String messageId) {
+    /**
+     * Internal: send a MIME message with canonical threading + Reply-To
+     * headers. {@code messageId} is the header to set; {@code threadRoot}
+     * (nullable) is the In-Reply-To / References anchor for replies.
+     * {@code ticketId} is used to compute the signed Reply-To so the
+     * inbound provider webhook can verify ticket identity independently
+     * of the Message-ID / In-Reply-To chain.
+     */
+    private void sendEmail(String to, String subject, String htmlContent,
+                           String messageId, String threadRoot, long ticketId) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
@@ -69,12 +95,33 @@ public class EmailService {
 
             if (messageId != null) {
                 message.setHeader("Message-ID", messageId);
-                message.setHeader("References", messageId);
+            }
+            if (threadRoot != null) {
+                message.setHeader("In-Reply-To", threadRoot);
+                message.setHeader("References", threadRoot);
+            }
+
+            // Signed Reply-To so the inbound webhook can verify ticket
+            // identity even when clients strip the Message-ID chain.
+            String secret = emailInboundSecret();
+            if (!secret.isEmpty()) {
+                helper.setReplyTo(
+                        MessageIdUtil.buildReplyTo(ticketId, secret, emailDomain()));
             }
 
             mailSender.send(message);
         } catch (MessagingException ex) {
             log.error("Failed to send email to {}: {}", to, ex.getMessage());
         }
+    }
+
+    private String emailDomain() {
+        String domain = properties.getEmail().getDomain();
+        return (domain == null || domain.isBlank()) ? "localhost" : domain;
+    }
+
+    private String emailInboundSecret() {
+        String secret = properties.getEmail().getInboundSecret();
+        return secret == null ? "" : secret;
     }
 }

--- a/src/test/java/dev/escalated/services/EmailServiceTest.java
+++ b/src/test/java/dev/escalated/services/EmailServiceTest.java
@@ -1,0 +1,144 @@
+package dev.escalated.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.models.AgentProfile;
+import dev.escalated.models.Reply;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketPriority;
+import dev.escalated.models.TicketStatus;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.thymeleaf.TemplateEngine;
+
+/**
+ * Unit tests for {@link EmailService}'s Message-ID / Reply-To wiring.
+ *
+ * <p>Uses a real {@link MimeMessage} + a {@link Mock} JavaMailSender so
+ * we can assert on the headers that the service actually sets. The
+ * Thymeleaf template engine is mocked to avoid pulling in real
+ * templates for these unit tests.
+ */
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @Mock private JavaMailSender mailSender;
+    @Mock private TemplateEngine templateEngine;
+
+    private EmailService service;
+    private EscalatedProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new EscalatedProperties();
+        properties.getEmail().setDomain("support.example.com");
+        properties.getEmail().setInboundSecret("test-secret-for-hmac");
+        service = new EmailService(mailSender, templateEngine, properties);
+
+        // Stub JavaMailSender so createMimeMessage returns a real
+        // MimeMessage we can inspect. Use a no-op session.
+        Session session = Session.getDefaultInstance(new Properties());
+        when(mailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage(session));
+        when(templateEngine.process(any(String.class), any())).thenReturn("<p>rendered</p>");
+    }
+
+    private Ticket newTicket() {
+        Ticket t = new Ticket();
+        t.setId(42L);
+        t.setSubject("Help");
+        t.setStatus(TicketStatus.OPEN);
+        t.setPriority(TicketPriority.MEDIUM);
+        t.setRequesterEmail("alice@example.com");
+        return t;
+    }
+
+    @Test
+    void sendTicketCreatedNotification_setsCanonicalMessageIdAndSignedReplyTo() throws Exception {
+        service.sendTicketCreatedNotification(newTicket());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        String[] messageId = sent.getHeader("Message-ID");
+        assertThat(messageId).isNotNull();
+        assertThat(messageId[0]).isEqualTo("<ticket-42@support.example.com>");
+
+        // No In-Reply-To on the initial notification (thread anchor).
+        assertThat(sent.getHeader("In-Reply-To")).isNull();
+
+        String[] replyTo = sent.getHeader("Reply-To");
+        assertThat(replyTo).isNotNull();
+        assertThat(replyTo[0]).matches("reply\\+42\\.[a-f0-9]{8}@support\\.example\\.com");
+    }
+
+    @Test
+    void sendReplyNotification_addsInReplyToAndReferencesPointingToTicketRoot() throws Exception {
+        Ticket ticket = newTicket();
+        AgentProfile agent = new AgentProfile();
+        agent.setEmail("agent@example.com");
+        ticket.setAssignedAgent(agent);
+
+        Reply reply = new Reply();
+        reply.setId(7L);
+        reply.setAuthorType("requester"); // requester reply → goes to agent
+        reply.setTicket(ticket);
+
+        service.sendReplyNotification(ticket, reply);
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        assertThat(sent.getHeader("Message-ID")[0])
+                .isEqualTo("<ticket-42-reply-7@support.example.com>");
+        assertThat(sent.getHeader("In-Reply-To")[0])
+                .isEqualTo("<ticket-42@support.example.com>");
+        assertThat(sent.getHeader("References")[0])
+                .isEqualTo("<ticket-42@support.example.com>");
+    }
+
+    @Test
+    void sendEmail_whenInboundSecretBlank_doesNotSetReplyTo() throws Exception {
+        properties.getEmail().setInboundSecret("");
+
+        service.sendTicketCreatedNotification(newTicket());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        // Message-ID still present; Reply-To omitted when we have no key.
+        assertThat(sent.getHeader("Message-ID")).isNotNull();
+        assertThat(sent.getHeader("Reply-To")).isNull();
+    }
+
+    @Test
+    void sendSatisfactionSurvey_doesNotSetMessageId_butStillSetsReplyTo() throws Exception {
+        service.sendSatisfactionSurvey(newTicket(), "https://example.com/survey");
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        // Survey is not part of the ticket thread — no Message-ID /
+        // In-Reply-To chain needed. But the Reply-To still routes back
+        // to the ticket so replies (e.g. "what about this other issue")
+        // land on the right ticket id.
+        assertThat(sent.getHeader("Message-ID")).isNull();
+        assertThat(sent.getHeader("In-Reply-To")).isNull();
+        assertThat(sent.getHeader("Reply-To")).isNotNull();
+    }
+}


### PR DESCRIPTION
Recovers auto-closed #25 (base feat/email-message-id squash-merged via #24). Rebased onto current main.