### PR TITLE
chore(deps): Spring Boot 4.0.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5"
+    id("org.springframework.boot") version "4.0.6"
     id("io.spring.dependency-management") version "1.1.7"
     `maven-publish`
     checkstyle
@@ -30,7 +30,6 @@ dependencies {
 
     implementation("org.flywaydb:flyway-core")
     implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("dev.samstevens.totp:totp-spring-boot-starter:1.7.1")
 
     runtimeOnly("com.h2database:h2")
     runtimeOnly("org.postgresql:postgresql")
@@ -39,6 +38,7 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testImplementation("org.springframework.security:spring-security-test")
 }
 

--- a/docker/host-app/build.gradle.kts
+++ b/docker/host-app/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5"
+    id("org.springframework.boot") version "4.0.6"
     id("io.spring.dependency-management") version "1.1.7"
 }
 
@@ -23,7 +23,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
-    implementation("dev.samstevens.totp:totp-spring-boot-starter:1.7.1")
     implementation("org.flywaydb:flyway-core")
     runtimeOnly("org.postgresql:postgresql")
     implementation(rootProject)

--- a/src/main/java/dev/escalated/config/EscalatedAutoConfiguration.java
+++ b/src/main/java/dev/escalated/config/EscalatedAutoConfiguration.java
@@ -2,7 +2,7 @@ package dev.escalated.config;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;

--- a/src/test/java/dev/escalated/controllers/AdminPublicTicketsSettingsControllerTest.java
+++ b/src/test/java/dev/escalated/controllers/AdminPublicTicketsSettingsControllerTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -38,10 +38,10 @@ class AdminPublicTicketsSettingsControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private ApiTokenAuthenticationFilter apiTokenFilter;
 
-    @MockBean
+    @MockitoBean
     private SettingsService settingsService;
 
     private Map<String, String> store;

--- a/src/test/java/dev/escalated/controllers/AdminTicketControllerTest.java
+++ b/src/test/java/dev/escalated/controllers/AdminTicketControllerTest.java
@@ -8,9 +8,9 @@ import dev.escalated.services.TicketService;
 import dev.escalated.security.ApiTokenAuthenticationFilter;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -34,10 +34,10 @@ class AdminTicketControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private ApiTokenAuthenticationFilter apiTokenFilter;
 
-    @MockBean
+    @MockitoBean
     private TicketService ticketService;
 
     @Test

--- a/src/test/java/dev/escalated/controllers/InboundEmailControllerTest.java
+++ b/src/test/java/dev/escalated/controllers/InboundEmailControllerTest.java
@@ -22,9 +22,9 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -50,13 +50,13 @@ class InboundEmailControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private ApiTokenAuthenticationFilter apiTokenFilter;
 
-    @MockBean
+    @MockitoBean
     private InboundEmailService inboundService;
 
-    @MockBean
+    @MockitoBean
     private EscalatedProperties properties;
 
     @BeforeEach

--- a/src/test/java/dev/escalated/controllers/WidgetControllerTest.java
+++ b/src/test/java/dev/escalated/controllers/WidgetControllerTest.java
@@ -10,9 +10,9 @@ import dev.escalated.services.TicketService;
 import dev.escalated.security.ApiTokenAuthenticationFilter;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -30,14 +30,14 @@ class WidgetControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private ApiTokenAuthenticationFilter apiTokenFilter;
 
-    @MockBean
+    @MockitoBean
     private TicketService ticketService;
-    @MockBean
+    @MockitoBean
     private KnowledgeBaseService knowledgeBaseService;
-    @MockBean
+    @MockitoBean
     private SatisfactionRatingService ratingService;
 
     @Test


### PR DESCRIPTION
## Summary

Bumps Spring Boot from 3.2.5 to 4.0.6 in both the library (`build.gradle.kts`) and the Docker host-app (`docker/host-app/build.gradle.kts`).

Bundles two dependabot PRs:
- #54 — Spring Boot bump (root)
- #48 — Spring Boot bump (docker/host-app)

Requires Gradle 9, already shipped via #55.

## Boot 4 migration changes

- `@EntityScan` moved from `o.s.boot.autoconfigure.domain` to `o.s.boot.persistence.autoconfigure`.
- `@WebMvcTest` / `@AutoConfigureMockMvc` moved from `o.s.boot.test.autoconfigure.web.servlet` to `o.s.boot.webmvc.test.autoconfigure`. These now live in a separate test starter, so `spring-boot-starter-webmvc-test` is added to `testImplementation`.
- `@MockBean` (Spring Boot) was removed in 4.0; replaced with Spring Framework 7's `@MockitoBean` (`o.s.test.context.bean.override.mockito.MockitoBean`) across the four `@WebMvcTest` test classes.
- Dropped unused `dev.samstevens.totp:totp-spring-boot-starter:1.7.1`. `TwoFactorService` implements TOTP from scratch using `javax.crypto.Mac` and never imported anything from the starter; the starter also hard-pinned `spring-boot-autoconfigure:2.2.5.RELEASE` as a transitive dep, which would have conflicted with Boot 4 dependency management.

## Test plan

- [x] `./gradlew clean build` (Temurin 17, Gradle 9.5.0) — green; 217 tests, 0 failures, 0 errors.
- [x] `./gradlew :docker:host-app:bootJar` (smoke) — green.
- [ ] CI green (Test workflow).