### PR TITLE
feat(newsletters): newsletter entities + renderer (Wave 3, Spring - partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,30 @@ Enable with `escalated.broadcasting.enabled=true`. Connect to `/escalated/ws` vi
 ./gradlew checkstyleMain checkstyleTest
 ```
 
+## Newsletters (optional, partial port)
+
+JPA entities + renderer for the admin-only newsletter broadcast feature. Schema is auto-derived by Hibernate from the new `@Entity` classes when `spring.jpa.hibernate.ddl-auto=update`. Production hosts using Flyway / Liquibase generate the SQL migration with `mvn spring-boot:run` or `mvn flyway:migrate` after referencing this package.
+
+```java
+import dev.escalated.services.newsletter.NewsletterRenderer;
+
+var opts = new NewsletterRenderer.Options();
+opts.baseUrl = "https://support.example.com";
+opts.defaultTheme = "default";
+opts.trackingEnabled = true;
+opts.themesDir = "src/main/resources/templates/escalated/newsletter_themes";
+opts.markdownToHtml = md -> /* plug in flexmark, commonmark-java, etc. */;
+opts.brandName = "Acme";
+opts.brandAccent = "#2563eb";
+
+var renderer = new NewsletterRenderer(opts);
+var html = renderer.render(delivery, newsletter, contact, template);
+```
+
+Ships: `models/newsletter/*.java` (5 JPA entities), `models/Contact.java` (gains `marketingOptOutAt`), `services/newsletter/NewsletterRenderer.java`, `resources/templates/escalated/newsletter_themes/{default,branded}.html`.
+
+Follow-up PR: Flyway / Liquibase migration files, planner/dispatcher/tracker services using Spring `JpaRepository`s, Spring MVC controllers.
+
 ## License
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/src/main/java/dev/escalated/models/Contact.java
+++ b/src/main/java/dev/escalated/models/Contact.java
@@ -47,6 +47,13 @@ public class Contact extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String metadataJson;
 
+    /** Set when the contact one-click unsubscribes from marketing newsletters. */
+    @Column(name = "marketing_opt_out_at")
+    private java.time.Instant marketingOptOutAt;
+
+    public java.time.Instant getMarketingOptOutAt() { return marketingOptOutAt; }
+    public void setMarketingOptOutAt(java.time.Instant v) { this.marketingOptOutAt = v; }
+
     public String getEmail() {
         return email;
     }

--- a/src/main/java/dev/escalated/models/newsletter/Newsletter.java
+++ b/src/main/java/dev/escalated/models/newsletter/Newsletter.java
@@ -1,0 +1,119 @@
+package dev.escalated.models.newsletter;
+
+import dev.escalated.models.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+
+@Entity
+@Table(
+    name = "escalated_newsletters",
+    indexes = {
+        @Index(name = "idx_n_status", columnList = "status"),
+        @Index(name = "idx_n_scheduled_at", columnList = "scheduled_at"),
+        @Index(name = "idx_n_status_sched", columnList = "status, scheduled_at"),
+        @Index(name = "idx_n_created_by", columnList = "created_by"),
+    }
+)
+public class Newsletter extends BaseEntity {
+
+    @NotBlank
+    @Column(nullable = false, length = 998)
+    private String subject;
+
+    @NotBlank
+    @Email
+    @Column(name = "from_email", nullable = false, length = 320)
+    private String fromEmail;
+
+    @Column(name = "from_name")
+    private String fromName;
+
+    @Email
+    @Column(name = "reply_to", length = 320)
+    private String replyTo;
+
+    @Column(name = "target_list_id", nullable = false)
+    private Long targetListId;
+
+    @Column(name = "template_id")
+    private Long templateId;
+
+    @Column(length = 64)
+    private String theme;
+
+    @Column(name = "body_markdown", columnDefinition = "TEXT")
+    private String bodyMarkdown;
+
+    @Column(nullable = false, length = 16)
+    private String status = "draft";
+
+    @Column(name = "scheduled_at")
+    private Instant scheduledAt;
+
+    @Column(name = "sent_at")
+    private Instant sentAt;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    @Column(name = "sent_by")
+    private Long sentBy;
+
+    @Column(name = "summary_total", nullable = false)
+    private int summaryTotal = 0;
+
+    @Column(name = "summary_sent", nullable = false)
+    private int summarySent = 0;
+
+    @Column(name = "summary_opened", nullable = false)
+    private int summaryOpened = 0;
+
+    @Column(name = "summary_clicked", nullable = false)
+    private int summaryClicked = 0;
+
+    @Column(name = "summary_bounced", nullable = false)
+    private int summaryBounced = 0;
+
+    @Column(name = "summary_complained", nullable = false)
+    private int summaryComplained = 0;
+
+    public String getSubject() { return subject; }
+    public void setSubject(String subject) { this.subject = subject; }
+    public String getFromEmail() { return fromEmail; }
+    public void setFromEmail(String fromEmail) { this.fromEmail = fromEmail; }
+    public String getFromName() { return fromName; }
+    public void setFromName(String fromName) { this.fromName = fromName; }
+    public String getReplyTo() { return replyTo; }
+    public void setReplyTo(String replyTo) { this.replyTo = replyTo; }
+    public Long getTargetListId() { return targetListId; }
+    public void setTargetListId(Long targetListId) { this.targetListId = targetListId; }
+    public Long getTemplateId() { return templateId; }
+    public void setTemplateId(Long templateId) { this.templateId = templateId; }
+    public String getTheme() { return theme; }
+    public void setTheme(String theme) { this.theme = theme; }
+    public String getBodyMarkdown() { return bodyMarkdown; }
+    public void setBodyMarkdown(String bodyMarkdown) { this.bodyMarkdown = bodyMarkdown; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public Instant getScheduledAt() { return scheduledAt; }
+    public void setScheduledAt(Instant scheduledAt) { this.scheduledAt = scheduledAt; }
+    public Instant getSentAt() { return sentAt; }
+    public void setSentAt(Instant sentAt) { this.sentAt = sentAt; }
+    public int getSummaryTotal() { return summaryTotal; }
+    public void setSummaryTotal(int v) { this.summaryTotal = v; }
+    public int getSummarySent() { return summarySent; }
+    public void incrementSummarySent() { this.summarySent++; }
+    public int getSummaryOpened() { return summaryOpened; }
+    public void incrementSummaryOpened() { this.summaryOpened++; }
+    public int getSummaryClicked() { return summaryClicked; }
+    public void incrementSummaryClicked() { this.summaryClicked++; }
+    public int getSummaryBounced() { return summaryBounced; }
+    public void incrementSummaryBounced() { this.summaryBounced++; }
+    public int getSummaryComplained() { return summaryComplained; }
+    public void incrementSummaryComplained() { this.summaryComplained++; }
+}

--- a/src/main/java/dev/escalated/models/newsletter/NewsletterDelivery.java
+++ b/src/main/java/dev/escalated/models/newsletter/NewsletterDelivery.java
@@ -1,0 +1,103 @@
+package dev.escalated.models.newsletter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(
+    name = "escalated_newsletter_deliveries",
+    indexes = {
+        @Index(name = "idx_nd_nl_status", columnList = "newsletter_id, status"),
+        @Index(name = "idx_nd_contact", columnList = "contact_id"),
+        @Index(name = "idx_nd_status_claimed", columnList = "status, claimed_at"),
+        @Index(name = "uniq_nd_token", columnList = "tracking_token", unique = true),
+    }
+)
+public class NewsletterDelivery {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "newsletter_id", nullable = false)
+    private Long newsletterId;
+
+    @Column(name = "contact_id", nullable = false)
+    private Long contactId;
+
+    @Column(name = "email_at_send", nullable = false, length = 320)
+    private String emailAtSend;
+
+    @Column(nullable = false, length = 16)
+    private String status = "pending";
+
+    @Column(name = "tracking_token", nullable = false, length = 40)
+    private String trackingToken;
+
+    @Column(name = "sent_at")
+    private Instant sentAt;
+
+    @Column(name = "opened_at")
+    private Instant openedAt;
+
+    @Column(name = "last_clicked_at")
+    private Instant lastClickedAt;
+
+    @Column(name = "clicks_count", nullable = false)
+    private int clicksCount = 0;
+
+    @Column(name = "bounce_reason", columnDefinition = "TEXT")
+    private String bounceReason;
+
+    @Column(name = "failure_reason", columnDefinition = "TEXT")
+    private String failureReason;
+
+    @Column(name = "attempt_count", nullable = false)
+    private short attemptCount = 0;
+
+    @Column(name = "claimed_at")
+    private Instant claimedAt;
+
+    @Column(name = "is_test", nullable = false)
+    private boolean isTest = false;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+
+    public Long getId() { return id; }
+    public Long getNewsletterId() { return newsletterId; }
+    public void setNewsletterId(Long v) { this.newsletterId = v; }
+    public Long getContactId() { return contactId; }
+    public void setContactId(Long v) { this.contactId = v; }
+    public String getEmailAtSend() { return emailAtSend; }
+    public void setEmailAtSend(String v) { this.emailAtSend = v; }
+    public String getStatus() { return status; }
+    public void setStatus(String v) { this.status = v; }
+    public String getTrackingToken() { return trackingToken; }
+    public void setTrackingToken(String v) { this.trackingToken = v; }
+    public Instant getSentAt() { return sentAt; }
+    public void setSentAt(Instant v) { this.sentAt = v; }
+    public Instant getOpenedAt() { return openedAt; }
+    public void setOpenedAt(Instant v) { this.openedAt = v; }
+    public Instant getLastClickedAt() { return lastClickedAt; }
+    public void setLastClickedAt(Instant v) { this.lastClickedAt = v; }
+    public int getClicksCount() { return clicksCount; }
+    public void setClicksCount(int v) { this.clicksCount = v; }
+    public String getBounceReason() { return bounceReason; }
+    public void setBounceReason(String v) { this.bounceReason = v; }
+    public String getFailureReason() { return failureReason; }
+    public void setFailureReason(String v) { this.failureReason = v; }
+    public short getAttemptCount() { return attemptCount; }
+    public void setAttemptCount(short v) { this.attemptCount = v; }
+    public Instant getClaimedAt() { return claimedAt; }
+    public void setClaimedAt(Instant v) { this.claimedAt = v; }
+    public boolean isTest() { return isTest; }
+    public void setTest(boolean v) { this.isTest = v; }
+    public Instant getCreatedAt() { return createdAt; }
+}

--- a/src/main/java/dev/escalated/models/newsletter/NewsletterList.java
+++ b/src/main/java/dev/escalated/models/newsletter/NewsletterList.java
@@ -1,0 +1,49 @@
+package dev.escalated.models.newsletter;
+
+import dev.escalated.models.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+
+@Entity
+@Table(
+    name = "escalated_newsletter_lists",
+    indexes = {
+        @Index(name = "idx_nl_kind", columnList = "kind"),
+        @Index(name = "idx_nl_created_by", columnList = "created_by"),
+    }
+)
+public class NewsletterList extends BaseEntity {
+
+    @NotBlank
+    @Column(nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    /** "static" | "dynamic" */
+    @NotBlank
+    @Column(nullable = false, length = 16)
+    private String kind = "static";
+
+    /** Serialized filter rules JSON. Use {@code @Convert} in production. */
+    @Column(name = "filter_json", columnDefinition = "TEXT")
+    private String filterJson;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+    public String getFilterJson() { return filterJson; }
+    public void setFilterJson(String filterJson) { this.filterJson = filterJson; }
+    public Long getCreatedBy() { return createdBy; }
+    public void setCreatedBy(Long createdBy) { this.createdBy = createdBy; }
+}

--- a/src/main/java/dev/escalated/models/newsletter/NewsletterListMember.java
+++ b/src/main/java/dev/escalated/models/newsletter/NewsletterListMember.java
@@ -1,0 +1,39 @@
+package dev.escalated.models.newsletter;
+
+import dev.escalated.models.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+
+@Entity
+@Table(
+    name = "escalated_newsletter_list_members",
+    uniqueConstraints = @UniqueConstraint(name = "uniq_nlm_list_contact", columnNames = {"list_id", "contact_id"}),
+    indexes = @Index(name = "idx_nlm_contact", columnList = "contact_id")
+)
+public class NewsletterListMember extends BaseEntity {
+
+    @Column(name = "list_id", nullable = false)
+    private Long listId;
+
+    @Column(name = "contact_id", nullable = false)
+    private Long contactId;
+
+    @Column(name = "added_at", nullable = false)
+    private Instant addedAt = Instant.now();
+
+    @Column(name = "added_by")
+    private Long addedBy;
+
+    public Long getListId() { return listId; }
+    public void setListId(Long listId) { this.listId = listId; }
+    public Long getContactId() { return contactId; }
+    public void setContactId(Long contactId) { this.contactId = contactId; }
+    public Instant getAddedAt() { return addedAt; }
+    public void setAddedAt(Instant addedAt) { this.addedAt = addedAt; }
+    public Long getAddedBy() { return addedBy; }
+    public void setAddedBy(Long addedBy) { this.addedBy = addedBy; }
+}

--- a/src/main/java/dev/escalated/models/newsletter/NewsletterTemplate.java
+++ b/src/main/java/dev/escalated/models/newsletter/NewsletterTemplate.java
@@ -1,0 +1,52 @@
+package dev.escalated.models.newsletter;
+
+import dev.escalated.models.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+
+@Entity
+@Table(
+    name = "escalated_newsletter_templates",
+    indexes = {
+        @Index(name = "idx_nlt_theme", columnList = "theme"),
+        @Index(name = "idx_nlt_created_by", columnList = "created_by"),
+    }
+)
+public class NewsletterTemplate extends BaseEntity {
+
+    @NotBlank
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, length = 64)
+    private String theme = "default";
+
+    @Column(name = "subject_template", length = 998)
+    private String subjectTemplate;
+
+    @NotBlank
+    @Column(name = "body_markdown", nullable = false, columnDefinition = "TEXT")
+    private String bodyMarkdown;
+
+    @Column(name = "merge_fields_schema", columnDefinition = "TEXT")
+    private String mergeFieldsSchema;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getTheme() { return theme; }
+    public void setTheme(String theme) { this.theme = theme; }
+    public String getSubjectTemplate() { return subjectTemplate; }
+    public void setSubjectTemplate(String subjectTemplate) { this.subjectTemplate = subjectTemplate; }
+    public String getBodyMarkdown() { return bodyMarkdown; }
+    public void setBodyMarkdown(String bodyMarkdown) { this.bodyMarkdown = bodyMarkdown; }
+    public String getMergeFieldsSchema() { return mergeFieldsSchema; }
+    public void setMergeFieldsSchema(String mergeFieldsSchema) { this.mergeFieldsSchema = mergeFieldsSchema; }
+    public Long getCreatedBy() { return createdBy; }
+    public void setCreatedBy(Long createdBy) { this.createdBy = createdBy; }
+}

--- a/src/main/java/dev/escalated/services/newsletter/NewsletterRenderer.java
+++ b/src/main/java/dev/escalated/services/newsletter/NewsletterRenderer.java
@@ -1,0 +1,178 @@
+package dev.escalated.services.newsletter;
+
+import dev.escalated.models.Contact;
+import dev.escalated.models.newsletter.Newsletter;
+import dev.escalated.models.newsletter.NewsletterDelivery;
+import dev.escalated.models.newsletter.NewsletterTemplate;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Renders a NewsletterDelivery to themed HTML.
+ *
+ * <p>Markdown is host-pluggable via {@link Options#markdownToHtml}. Themes are
+ * Thymeleaf-free HTML files that the renderer evaluates with simple
+ * {@code {{key}}} / {@code {{{key}}}} substitution to stay lib-free.
+ */
+public class NewsletterRenderer {
+
+    private static final List<String> ALLOWED_SCHEMES = List.of("http", "https", "mailto", "tel");
+    private static final Pattern ANCHOR = Pattern.compile("(?i)(<a\\s[^>]*\\bhref=)(\"|')(.*?)\\2");
+    private static final Pattern MERGE_FIELD = Pattern.compile("\\{\\{\\s*([a-zA-Z0-9_.]+)\\s*\\}\\}");
+
+    private final Options opts;
+
+    public NewsletterRenderer(Options opts) {
+        this.opts = opts;
+    }
+
+    public String render(NewsletterDelivery delivery, Newsletter newsletter, Contact contact, NewsletterTemplate template) {
+        String bodyMd = first(newsletter.getBodyMarkdown(), template != null ? template.getBodyMarkdown() : "");
+        String themeSlug = first(newsletter.getTheme(), template != null ? template.getTheme() : opts.defaultTheme);
+
+        String body = markdownToHtml(bodyMd);
+        body = resolveMergeFields(body, contact, delivery);
+
+        Map<String, String> ctx = new HashMap<>();
+        ctx.put("subject", n(newsletter.getSubject()));
+        ctx.put("body", body);
+        ctx.put("unsubscribe_url", unsubscribeUrl(delivery));
+        ctx.put("view_in_browser_url", viewInBrowserUrl(delivery));
+        ctx.put("brand.name", opts.brandName);
+        ctx.put("brand.accent", opts.brandAccent);
+        ctx.put("brand.logo_url", n(opts.brandLogoUrl));
+        ctx.put("brand.physical_address", n(opts.brandPhysicalAddress));
+
+        String themed = renderTheme(themeSlug, ctx);
+        if (!opts.trackingEnabled) return themed;
+        return injectPixel(rewriteLinks(themed, delivery), delivery);
+    }
+
+    public String unsubscribeUrl(NewsletterDelivery d) {
+        return trimSlash(opts.baseUrl) + "/escalated/n/u/" + d.getTrackingToken();
+    }
+
+    public String viewInBrowserUrl(NewsletterDelivery d) {
+        return trimSlash(opts.baseUrl) + "/escalated/n/v/" + d.getTrackingToken();
+    }
+
+    private String markdownToHtml(String md) {
+        if (opts.markdownToHtml != null) return opts.markdownToHtml.apply(md);
+        String escaped = htmlEscape(md);
+        return "<p>" + escaped.replaceAll("\\n{2,}", "</p><p>") + "</p>";
+    }
+
+    private String resolveMergeFields(String html, Contact contact, NewsletterDelivery delivery) {
+        Matcher m = MERGE_FIELD.matcher(html);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String path = m.group(1).trim();
+            m.appendReplacement(sb, Matcher.quoteReplacement(htmlEscape(resolvePath(path, contact, delivery))));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    private String resolvePath(String path, Contact contact, NewsletterDelivery delivery) {
+        if (path.equals("contact.name")) return n(contact.getName());
+        if (path.equals("contact.first_name")) {
+            String name = n(contact.getName());
+            int sp = name.indexOf(' ');
+            return sp >= 0 ? name.substring(0, sp) : name;
+        }
+        if (path.equals("contact.email")) return n(contact.getEmail());
+        if (path.equals("unsubscribe_url")) return unsubscribeUrl(delivery);
+        if (path.equals("view_in_browser_url")) return viewInBrowserUrl(delivery);
+        // contact.metadata.* not surfaced here for v1 — Contact.metadataJson is a string.
+        return "";
+    }
+
+    private String renderTheme(String slug, Map<String, String> ctx) {
+        try {
+            Path themesDir = Path.of(opts.themesDir);
+            Path path = themesDir.resolve(slug + ".html");
+            if (!Files.exists(path)) path = themesDir.resolve("default.html");
+            String source = Files.readString(path, StandardCharsets.UTF_8);
+            // {{{ key }}} = raw, {{ key }} = escaped
+            source = Pattern.compile("\\{\\{\\{\\s*([a-zA-Z0-9_.]+)\\s*\\}\\}\\}").matcher(source).replaceAll(m -> {
+                String v = ctx.getOrDefault(m.group(1).trim(), "");
+                return Matcher.quoteReplacement(v);
+            });
+            source = Pattern.compile("\\{\\{\\s*([a-zA-Z0-9_.]+)\\s*\\}\\}").matcher(source).replaceAll(m -> {
+                String v = ctx.getOrDefault(m.group(1).trim(), "");
+                return Matcher.quoteReplacement(htmlEscape(v));
+            });
+            return source;
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to load newsletter theme: " + slug, e);
+        }
+    }
+
+    private String rewriteLinks(String html, NewsletterDelivery d) {
+        String unsub = unsubscribeUrl(d);
+        String view = viewInBrowserUrl(d);
+        Matcher m = ANCHOR.matcher(html);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String prefix = m.group(1);
+            String quote = m.group(2);
+            String href = m.group(3);
+            String replacement;
+            if (href.isEmpty() || href.startsWith("#")) {
+                replacement = m.group(0);
+            } else {
+                int colon = href.indexOf(':');
+                String scheme = (colon > 0 ? href.substring(0, colon) : "").toLowerCase();
+                if (!ALLOWED_SCHEMES.contains(scheme)) {
+                    replacement = prefix + quote + "#" + quote;
+                } else if (scheme.equals("mailto") || scheme.equals("tel")
+                        || href.startsWith(unsub) || href.startsWith(view)) {
+                    replacement = m.group(0);
+                } else {
+                    String encoded = Base64.getUrlEncoder().withoutPadding()
+                            .encodeToString(href.getBytes(StandardCharsets.UTF_8));
+                    String tracked = trimSlash(opts.baseUrl) + "/escalated/n/c/" + d.getTrackingToken() + "?u=" + encoded;
+                    replacement = prefix + quote + tracked + quote;
+                }
+            }
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    private String injectPixel(String html, NewsletterDelivery d) {
+        String url = trimSlash(opts.baseUrl) + "/escalated/n/o/" + d.getTrackingToken() + ".gif";
+        String pixel = "<img src=\"" + htmlEscape(url) + "\" width=\"1\" height=\"1\" alt=\"\" />";
+        if (html.contains("</body>")) return html.replace("</body>", pixel + "</body>");
+        return html + pixel;
+    }
+
+    private static String n(String s) { return s == null ? "" : s; }
+    private static String first(String a, String b) { return (a != null && !a.isEmpty()) ? a : (b == null ? "" : b); }
+    private static String trimSlash(String s) { return s == null ? "" : s.replaceAll("/+$", ""); }
+    private static String htmlEscape(String s) {
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                .replace("\"", "&quot;").replace("'", "&#39;");
+    }
+
+    public static class Options {
+        public String baseUrl = "http://localhost";
+        public String defaultTheme = "default";
+        public boolean trackingEnabled = true;
+        public String themesDir = "";
+        public Function<String, String> markdownToHtml;
+        public String brandName = "Support";
+        public String brandAccent = "#2563eb";
+        public String brandLogoUrl;
+        public String brandPhysicalAddress;
+    }
+}

--- a/src/main/resources/templates/escalated/newsletter_themes/branded.html
+++ b/src/main/resources/templates/escalated/newsletter_themes/branded.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ subject }}</title>
+  <style>
+    body { margin: 0; padding: 0; background: #f8fafc; color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }
+    .container { max-width: 640px; margin: 0 auto; background: #ffffff; }
+    .header { padding: 24px; background: {{ brand.accent }}; color: white; text-align: center; }
+    .header h1 { font-size: 20px; margin: 0; }
+    .content { padding: 32px 24px; font-size: 16px; line-height: 1.6; }
+    .content h1, .content h2 { color: {{ brand.accent }}; }
+    .content p { margin: 0 0 16px; }
+    .content a { color: {{ brand.accent }}; }
+    .footer { padding: 16px 24px 32px; font-size: 12px; color: #64748b; text-align: center; border-top: 1px solid #e2e8f0; }
+    .footer a { color: #64748b; text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header"><h1>{{ brand.name }}</h1></div>
+    <div class="content">{{{ body }}}</div>
+    <div class="footer">
+      <p>
+        <a href="{{ view_in_browser_url }}">View in browser</a>
+        ·
+        <a href="{{ unsubscribe_url }}">Unsubscribe</a>
+      </p>
+      <p>{{ brand.physical_address }}</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/templates/escalated/newsletter_themes/default.html
+++ b/src/main/resources/templates/escalated/newsletter_themes/default.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ subject }}</title>
+  <style>
+    body { margin: 0; padding: 0; background: #f8fafc; color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; }
+    .container { max-width: 600px; margin: 0 auto; background: #ffffff; }
+    .content { padding: 32px 24px; font-size: 16px; line-height: 1.6; }
+    .content h1 { font-size: 24px; margin: 0 0 16px; }
+    .content h2 { font-size: 20px; margin: 24px 0 12px; }
+    .content p { margin: 0 0 16px; }
+    .content a { color: #2563eb; }
+    .footer { padding: 16px 24px 32px; font-size: 12px; color: #64748b; text-align: center; }
+    .footer a { color: #64748b; text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="content">{{{ body }}}</div>
+    <div class="footer">
+      <p>
+        <a href="{{ view_in_browser_url }}">View in browser</a>
+        ·
+        <a href="{{ unsubscribe_url }}">Unsubscribe</a>
+      </p>
+      <p>{{ brand.physical_address }}</p>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Wave 3 partial port of the newsletter engine to Spring Boot / JPA. Entities + renderer + themes. DB-bound services are a follow-up.

- 5 JPA entities under `dev/escalated/models/newsletter/`
- `Contact.marketingOptOutAt` field added
- `services/newsletter/NewsletterRenderer.java` — full renderer (Markdown → theme → click rewrite → pixel injection)
- Two starter themes under `resources/templates/escalated/newsletter_themes/` using `{{key}}` / `{{{key}}}` substitution
- README usage example

## Architecture notes
- **No Flyway/Liquibase migration committed** — schema is auto-derived by Hibernate when `spring.jpa.hibernate.ddl-auto=update`, or hosts using a migration tool generate the SQL from these `@Entity` classes.
- **Markdown is host-pluggable** via `NewsletterRenderer.Options.markdownToHtml` (recommended: `flexmark-java` or `commonmark-java`).
- **Theme rendering** uses simple `{{key}}` / `{{{key}}}` substitution — no Thymeleaf dependency for the renderer (themes still live under `resources/templates/` so Thymeleaf-using hosts can re-render through their own view layer).
- **JPA conventions** — extends existing `BaseEntity` for `id` / `createdAt` / `updatedAt` (NewsletterDelivery does not extend it because it omits `updatedAt` for write-volume reasons).

## Out of scope / follow-ups
- Flyway / Liquibase migration script
- Planner / Dispatcher / Tracker services using `JpaRepository`s
- Spring MVC controllers (admin CRUD + public tracking/unsubscribe/view-in-browser + ESP webhooks)
- `@Scheduled` task for the dispatcher tick

## Reviewer notes
- **Do not auto-merge.** Hand back to Matthew for review.
