### PR TITLE
feat(tickets): custom ticket actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,41 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
+## Custom Ticket Actions
+
+Host applications can add custom buttons to the agent ticket screen and handle
+clicks with a Spring `@EventListener`. Register actions in `application.yml`:
+
+```yaml
+escalated:
+  ticket-actions:
+    - key: sync-crm
+      label: Sync CRM
+      variant: primary          # primary | secondary | danger
+      confirmation: "Sync this ticket to the CRM?"
+      metadata:
+        icon: refresh-cw
+```
+
+Visible actions are exposed on the agent ticket detail response as
+`custom_actions` (each with a `url` and `method`). Triggering one
+(`POST /escalated/api/agent/tickets/{id}/actions/{action}`) validates the action
+is visible (404) and enabled (403), records an internal note for auditability,
+and publishes a `CustomActionTriggeredEvent`:
+
+```java
+@Component
+public class CrmSyncListener {
+    @EventListener
+    public void onCustomAction(CustomActionTriggeredEvent event) {
+        if (!"sync-crm".equals(event.getAction())) {
+            return;
+        }
+        // event.getTicket(), event.getUserEmail(), event.getPayload(), event.getMetadata()
+    }
+}
+```
+
 ## Database Setup
 
 Flyway migrations are included and run automatically. The migration creates all tables prefixed with `escalated_` and seeds default roles and permissions.

--- a/src/main/java/dev/escalated/config/EscalatedProperties.java
+++ b/src/main/java/dev/escalated/config/EscalatedProperties.java
@@ -1,5 +1,8 @@
 package dev.escalated.config;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "escalated")
@@ -16,6 +19,7 @@ public class EscalatedProperties {
     private WidgetProperties widget = new WidgetProperties();
     private GuestAccessProperties guestAccess = new GuestAccessProperties();
     private EmailProperties email = new EmailProperties();
+    private List<TicketActionProperties> ticketActions = new ArrayList<>();
 
     public boolean isEnabled() {
         return enabled;
@@ -103,6 +107,84 @@ public class EscalatedProperties {
 
     public void setEmail(EmailProperties email) {
         this.email = email;
+    }
+
+    public List<TicketActionProperties> getTicketActions() {
+        return ticketActions;
+    }
+
+    public void setTicketActions(List<TicketActionProperties> ticketActions) {
+        this.ticketActions = ticketActions;
+    }
+
+    /**
+     * A host-defined custom ticket action button, bound from the
+     * {@code escalated.ticket-actions} configuration list.
+     */
+    public static class TicketActionProperties {
+        private String key;
+        private String label;
+        private String variant = "secondary";
+        private boolean visible = true;
+        private boolean enabled = true;
+        private String confirmation;
+        private Map<String, Object> metadata;
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public String getVariant() {
+            return variant;
+        }
+
+        public void setVariant(String variant) {
+            this.variant = variant;
+        }
+
+        public boolean isVisible() {
+            return visible;
+        }
+
+        public void setVisible(boolean visible) {
+            this.visible = visible;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getConfirmation() {
+            return confirmation;
+        }
+
+        public void setConfirmation(String confirmation) {
+            this.confirmation = confirmation;
+        }
+
+        public Map<String, Object> getMetadata() {
+            return metadata;
+        }
+
+        public void setMetadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+        }
     }
 
     public static class KnowledgeBaseProperties {

--- a/src/main/java/dev/escalated/controllers/agent/AgentTicketController.java
+++ b/src/main/java/dev/escalated/controllers/agent/AgentTicketController.java
@@ -1,16 +1,21 @@
 package dev.escalated.controllers.agent;
 
+import dev.escalated.config.EscalatedProperties;
 import dev.escalated.dto.TicketDetailDto;
+import dev.escalated.events.CustomActionTriggeredEvent;
 import dev.escalated.models.Reply;
 import dev.escalated.models.Ticket;
 import dev.escalated.models.TicketStatus;
 import dev.escalated.services.CannedResponseService;
 import dev.escalated.services.MacroService;
 import dev.escalated.services.SideConversationService;
+import dev.escalated.services.TicketActionRegistry;
 import dev.escalated.services.TicketLinkService;
 import dev.escalated.services.TicketService;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -31,15 +36,30 @@ public class AgentTicketController {
     private final MacroService macroService;
     private final SideConversationService sideConversationService;
     private final TicketLinkService ticketLinkService;
+    private final TicketActionRegistry ticketActionRegistry;
+    private final ApplicationEventPublisher eventPublisher;
 
     public AgentTicketController(TicketService ticketService,
                                  MacroService macroService,
                                  SideConversationService sideConversationService,
-                                 TicketLinkService ticketLinkService) {
+                                 TicketLinkService ticketLinkService,
+                                 TicketActionRegistry ticketActionRegistry,
+                                 ApplicationEventPublisher eventPublisher) {
         this.ticketService = ticketService;
         this.macroService = macroService;
         this.sideConversationService = sideConversationService;
         this.ticketLinkService = ticketLinkService;
+        this.ticketActionRegistry = ticketActionRegistry;
+        this.eventPublisher = eventPublisher;
+    }
+
+    private List<Map<String, Object>> customActionsForTicket(Long ticketId) {
+        List<Map<String, Object>> actions = ticketActionRegistry.forTicket();
+        for (Map<String, Object> action : actions) {
+            action.put("url", "/escalated/api/agent/tickets/" + ticketId + "/actions/" + action.get("key"));
+            action.put("method", "post");
+        }
+        return actions;
     }
 
     @GetMapping
@@ -57,7 +77,39 @@ public class AgentTicketController {
 
     @GetMapping("/{id}")
     public ResponseEntity<TicketDetailDto> show(@PathVariable Long id) {
-        return ResponseEntity.ok(ticketService.findByIdWithDetail(id));
+        TicketDetailDto dto = ticketService.findByIdWithDetail(id);
+        dto.setCustomActions(customActionsForTicket(id));
+        return ResponseEntity.ok(dto);
+    }
+
+    @PostMapping("/{id}/actions/{action}")
+    public ResponseEntity<Object> customAction(@PathVariable Long id, @PathVariable String action,
+                                               @RequestBody(required = false) Map<String, Object> body) {
+        EscalatedProperties.TicketActionProperties config = ticketActionRegistry.find(action);
+        if (config == null || !config.isVisible()) {
+            return ResponseEntity.status(404).body(Map.of("error", "Custom action not found"));
+        }
+        if (!config.isEnabled()) {
+            return ResponseEntity.status(403).body(Map.of("error", "Custom action is not enabled"));
+        }
+
+        Ticket ticket = ticketService.findById(id);
+        String actorEmail = body == null ? null : (String) body.get("actor_email");
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        Object rawPayload = body == null ? null : body.get("payload");
+        if (rawPayload instanceof Map<?, ?> map) {
+            map.forEach((k, v) -> payload.put(String.valueOf(k), v));
+        }
+
+        // Record an internal note for auditability.
+        ticketService.addReply(id, "Custom action \"" + action + "\" was triggered.",
+                "System", actorEmail, "agent", true);
+
+        eventPublisher.publishEvent(new CustomActionTriggeredEvent(this, ticket, action, actorEmail,
+                payload, config.getMetadata()));
+
+        return ResponseEntity.ok(Map.of("message", "Custom action dispatched.", "action", action));
     }
 
     @GetMapping("/{id}/replies")

--- a/src/main/java/dev/escalated/dto/TicketDetailDto.java
+++ b/src/main/java/dev/escalated/dto/TicketDetailDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import dev.escalated.models.Reply;
 import dev.escalated.models.Ticket;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -35,6 +36,9 @@ public class TicketDetailDto {
 
     @JsonProperty("related_tickets")
     private final List<RelatedTicketDto> relatedTickets;
+
+    @JsonProperty("custom_actions")
+    private List<Map<String, Object>> customActions = new ArrayList<>();
 
     public TicketDetailDto(Ticket ticket,
                            Long chatSessionId,
@@ -78,6 +82,14 @@ public class TicketDetailDto {
 
     public List<RelatedTicketDto> getRelatedTickets() {
         return relatedTickets;
+    }
+
+    public List<Map<String, Object>> getCustomActions() {
+        return customActions;
+    }
+
+    public void setCustomActions(List<Map<String, Object>> customActions) {
+        this.customActions = customActions;
     }
 
     /**

--- a/src/main/java/dev/escalated/events/CustomActionTriggeredEvent.java
+++ b/src/main/java/dev/escalated/events/CustomActionTriggeredEvent.java
@@ -1,0 +1,49 @@
+package dev.escalated.events;
+
+import dev.escalated.models.Ticket;
+import java.util.Map;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Published when an agent triggers a host-defined custom ticket action.
+ * Host applications listen for this with {@code @EventListener} to run their
+ * own work (CRM sync, etc.).
+ */
+public class CustomActionTriggeredEvent extends ApplicationEvent {
+
+    private final Ticket ticket;
+    private final String action;
+    private final String userEmail;
+    private final Map<String, Object> payload;
+    private final Map<String, Object> metadata;
+
+    public CustomActionTriggeredEvent(Object source, Ticket ticket, String action, String userEmail,
+                                      Map<String, Object> payload, Map<String, Object> metadata) {
+        super(source);
+        this.ticket = ticket;
+        this.action = action;
+        this.userEmail = userEmail;
+        this.payload = payload;
+        this.metadata = metadata;
+    }
+
+    public Ticket getTicket() {
+        return ticket;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public Map<String, Object> getPayload() {
+        return payload;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+}

--- a/src/main/java/dev/escalated/services/TicketActionRegistry.java
+++ b/src/main/java/dev/escalated/services/TicketActionRegistry.java
@@ -1,0 +1,66 @@
+package dev.escalated.services;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.config.EscalatedProperties.TicketActionProperties;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves host-defined custom ticket actions registered under the
+ * {@code escalated.ticket-actions} configuration list. Each visible action
+ * renders as a button on the agent ticket screen; triggering it records an
+ * internal note and publishes a {@code CustomActionTriggeredEvent}.
+ *
+ * <p>Mirrors the Laravel TicketActionRegistry / NestJS reference.
+ */
+@Service
+public class TicketActionRegistry {
+
+    private final List<TicketActionProperties> actions;
+
+    public TicketActionRegistry(EscalatedProperties properties) {
+        this.actions = new ArrayList<>();
+        for (TicketActionProperties action : properties.getTicketActions()) {
+            boolean hasKey = action.getKey() != null && !action.getKey().isEmpty();
+            boolean hasLabel = action.getLabel() != null && !action.getLabel().isEmpty();
+            if (hasKey && hasLabel) {
+                this.actions.add(action);
+            }
+        }
+    }
+
+    /** Find a configured action by key, or {@code null}. */
+    public TicketActionProperties find(String key) {
+        for (TicketActionProperties action : actions) {
+            if (action.getKey().equals(key)) {
+                return action;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The visible actions, serialized for the UI. The controller adds the
+     * {@code url} and {@code method} before responding.
+     */
+    public List<Map<String, Object>> forTicket() {
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (TicketActionProperties action : actions) {
+            if (!action.isVisible()) {
+                continue;
+            }
+            Map<String, Object> map = new LinkedHashMap<>();
+            map.put("key", action.getKey());
+            map.put("label", action.getLabel());
+            map.put("variant", action.getVariant());
+            map.put("confirmation", action.getConfirmation());
+            map.put("disabled", !action.isEnabled());
+            map.put("metadata", action.getMetadata() != null ? action.getMetadata() : new LinkedHashMap<>());
+            result.add(map);
+        }
+        return result;
+    }
+}

--- a/src/test/java/dev/escalated/services/TicketActionRegistryTest.java
+++ b/src/test/java/dev/escalated/services/TicketActionRegistryTest.java
@@ -1,0 +1,62 @@
+package dev.escalated.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.config.EscalatedProperties.TicketActionProperties;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TicketActionRegistryTest {
+
+    private TicketActionProperties action(String key, String label) {
+        TicketActionProperties a = new TicketActionProperties();
+        a.setKey(key);
+        a.setLabel(label);
+        return a;
+    }
+
+    private TicketActionRegistry registry(TicketActionProperties... actions) {
+        EscalatedProperties props = new EscalatedProperties();
+        props.setTicketActions(List.of(actions));
+        return new TicketActionRegistry(props);
+    }
+
+    @Test
+    void forTicketSerializesVisibleActionsWithDefaults() {
+        TicketActionRegistry reg = registry(action("sync-crm", "Sync CRM"));
+
+        List<Map<String, Object>> actions = reg.forTicket();
+
+        assertEquals(1, actions.size());
+        assertEquals("sync-crm", actions.get(0).get("key"));
+        assertEquals("Sync CRM", actions.get(0).get("label"));
+        assertEquals("secondary", actions.get(0).get("variant"));
+        assertEquals(false, actions.get(0).get("disabled"));
+    }
+
+    @Test
+    void omitsInvisibleActionsAndMarksDisabled() {
+        TicketActionProperties hidden = action("hidden", "Hidden");
+        hidden.setVisible(false);
+        TicketActionProperties locked = action("locked", "Locked");
+        locked.setEnabled(false);
+
+        List<Map<String, Object>> actions = registry(hidden, locked).forTicket();
+
+        assertEquals(1, actions.size());
+        assertEquals("locked", actions.get(0).get("key"));
+        assertEquals(true, actions.get(0).get("disabled"));
+    }
+
+    @Test
+    void findReturnsConfigOrNull() {
+        TicketActionRegistry reg = registry(action("a", "A"));
+
+        assertNotNull(reg.find("a"));
+        assertNull(reg.find("missing"));
+    }
+}


### PR DESCRIPTION
Ports the **Custom Ticket Actions** feature to the Spring library. Backend counterpart to escalated-laravel#107 (reference: escalated-nestjs#57); shared frontend in escalated-dev/escalated#82.

## What
Host apps register actions under `escalated.ticket-actions` in `application.yml`. Visible actions are exposed on the agent ticket detail response as `custom_actions` (each with `url` + `method`). Triggering one records an internal note and publishes `CustomActionTriggeredEvent` via Spring's `ApplicationEventPublisher`.

## Pieces
- `TicketActionRegistry` `@Service` reading `EscalatedProperties.ticketActions`; `find(key)` + `forTicket()`.
- `EscalatedProperties.TicketActionProperties` + `ticketActions` list (`@ConfigurationProperties`).
- `CustomActionTriggeredEvent extends ApplicationEvent`.
- `AgentTicketController.customAction` (`POST /{id}/actions/{action}`): 404 unknown/not-visible, 403 disabled, else note + event; plus `custom_actions` set on the `show` DTO.
- `TicketDetailDto.customActions` (`@JsonProperty("custom_actions")`).
- README "Custom Ticket Actions" section.

## Testing
- JUnit `TicketActionRegistryTest` (serialization, visibility/disabled, find).
- ⚠️ **No local JDK/Gradle on the dev box**, so I could not run `./gradlew test` or `./gradlew checkstyleMain checkstyleTest`. Code was hand-written to mirror the existing properties/events/controller/DTO patterns exactly (constructor injection, `@JsonProperty`, explicit imports / no star-imports for Checkstyle). Please run CI on review — happy to fix any Checkstyle drift.