### PR TITLE
fix(users): support UUID/string host user keys

### DIFF
--- a/PROMPT-CURSOR-SKILLS.md
+++ b/PROMPT-CURSOR-SKILLS.md
@@ -1,0 +1,84 @@
+# Cursor task: skills-management parity for escalated-spring
+
+Read this whole file before doing anything. Self-contained brief.
+
+## Goal
+
+Bring `escalated-spring` to feature parity with the canonical Skills-management contract.
+
+**Tracking issue:** https://github.com/escalated-dev/escalated-spring/issues/60
+**Canonical contract:** https://github.com/escalated-dev/escalated-developer-context/blob/main/domain-model/skills-management.md
+**ADR:** https://github.com/escalated-dev/escalated-developer-context/blob/main/decisions/2026-05-13-skills-routing-explicit-mapping.md
+**NestJS reference (study):** https://github.com/escalated-dev/escalated-nestjs/pull/45
+**Frontend contract:** https://github.com/escalated-dev/escalated/pull/65
+
+## Current state
+
+- `src/main/java/dev/escalated/models/Skill.java`: JPA `@Entity Skill` with name, description, `@ManyToMany(mappedBy="skills") Set<AgentProfile> agents`. **No proficiency tracking, no junction entity.**
+- `src/main/java/dev/escalated/repositories/SkillRepository.java`: exists, basic Spring Data JPA.
+- **No** AgentSkill junction entity, no controller, no routing service, no admin UI.
+
+## Deliverables
+
+1. **Flyway / Liquibase migrations** (in `src/main/resources/db/migration/` — match the existing repo's migration tool):
+   - `V<next>__create_escalated_agent_skills.sql` — create the junction table: `id` PK, `user_id` BIGINT, `skill_id` BIGINT FK cascade, `proficiency` SMALLINT default 3, `created_at`/`updated_at`, unique `(user_id, skill_id)`, check constraint `1 <= proficiency <= 5`.
+   - `V<next+1>__create_escalated_skill_routing_tags.sql` — `id` PK, `skill_id` FK cascade, `tag_id` FK cascade, unique `(skill_id, tag_id)`, timestamps.
+   - `V<next+2>__create_escalated_skill_routing_departments.sql` — `id` PK, `skill_id` FK cascade, `department_id` FK cascade, unique `(skill_id, department_id)`, timestamps.
+   - If the existing `Skill.agents` M2M (between `Skill` and `AgentProfile`) was backed by a table, drop it in favour of the new junction. Otherwise leave alone.
+
+2. **JPA entities** (`src/main/java/dev/escalated/models/`):
+   - `AgentSkill.java` — `@Entity` with `Long id`, `Long userId`, `@ManyToOne Skill skill`, `Integer proficiency` (1..5, validated), timestamps. `@Table(name = "escalated_agent_skills")`. Unique constraint on (userId, skillId).
+   - `SkillRoutingTag.java` and `SkillRoutingDepartment.java` — junction entities.
+   - Update `Skill.java`: drop the old M2M to `AgentProfile.skills`. Add `@OneToMany List<AgentSkill> agentSkills`, `@OneToMany List<SkillRoutingTag> routingTags`, `@OneToMany List<SkillRoutingDepartment> routingDepartments`. Add `description` if missing, add timestamps.
+   - Update `AgentProfile` to drop its M2M `Set<Skill> skills` if it had one.
+
+3. **Repositories**:
+   - `AgentSkillRepository extends JpaRepository<AgentSkill, Long>` with `findByUserId`, `findBySkillId`, `deleteByUserId(Long userId)`, etc.
+   - `SkillRoutingTagRepository`, `SkillRoutingDepartmentRepository`.
+
+4. **DTOs** (`src/main/java/dev/escalated/dtos/admin/`):
+   - `CreateSkillDto` / `UpdateSkillDto` with `name`, `description`, `routingTagIds: List<Long>`, `routingDepartmentIds: List<Long>`, `agents: List<AgentSkillEntryDto>`.
+   - `AgentSkillEntryDto` with `userId: Long`, `proficiency: Integer` (`@Min(1) @Max(5)`).
+   - Use Bean Validation (`@Valid` / `@NotNull` / etc.).
+
+5. **Service** (`src/main/java/dev/escalated/services/SkillService.java`):
+   - `listForAdmin()` → returns rows with the three count fields.
+   - `findForEdit(id)` → returns the routing tag/department ID arrays and agent rows.
+   - `getFormContext()` → returns available tags, departments, agents.
+   - `create(dto)` / `update(id, dto)` / `delete(id)` — `@Transactional`, syncs all relations.
+   - Add a `SkillRoutingService` if not present — `findMatchingAgents(Ticket ticket)` returning eligible users per the contract.
+
+6. **Controller** (`src/main/java/dev/escalated/controllers/admin/SkillController.java`):
+   - 6 endpoints under `/escalated/admin/skills`: GET (index), GET `/new`, POST, GET `/{id}/edit`, PUT `/{id}`, DELETE `/{id}`.
+   - JSON request/response matching the contract.
+   - Wrap writes in `@Transactional`.
+
+7. **Tests** (`src/test/java/dev/escalated/`):
+   - Controller integration tests via `MockMvc` covering the 6 endpoints.
+   - Service tests for relation sync and proficiency persistence.
+   - Routing service test asserting explicit-mapping behaviour.
+
+## Process
+
+1. `git checkout -b feat/admin-skills-management`.
+2. Read the contract + NestJS PR diff before coding.
+3. Implement: migrations → entities → repositories → DTOs → service → controller → tests.
+4. Run: `./gradlew test` (or `mvn test`) until green, `./gradlew spotlessApply` (or whatever the repo uses) for formatting.
+5. Commit logically, reference #60.
+6. Push, open PR titled `feat(skills): admin skills management parity (#60)`.
+
+## Constraints
+
+- Wrap multi-table writes in `@Transactional`.
+- Use Spring Data JPA conventions consistent with the rest of the codebase.
+- Snake_case at the wire IF the rest of the controllers use snake_case; otherwise match local convention (Spring/Jackson default is camelCase).
+- Don't touch unrelated files.
+- Stop after pushing the PR. Do not auto-merge.
+- The PROMPT file you're reading is untracked — do not include it in the PR.
+
+## Self-check before pushing
+
+- `./gradlew test` (or `mvn test`) — all green
+- `./gradlew spotlessCheck` (or repo's lint task) — clean
+- `git log --oneline` shows your commits
+- All 7 deliverables addressed

--- a/src/main/java/dev/escalated/models/AgentProfile.java
+++ b/src/main/java/dev/escalated/models/AgentProfile.java
@@ -25,8 +25,10 @@ public class AgentProfile extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;
 
+    // Optional link to the host app's user. Stored as a string so hosts with
+    // UUID/string user primary keys (not just integer ids) can be linked.
     @Column(name = "user_id")
-    private Long userId;
+    private String userId;
 
     @Column(name = "is_active", nullable = false)
     private boolean active = true;
@@ -85,11 +87,11 @@ public class AgentProfile extends BaseEntity {
         this.email = email;
     }
 
-    public Long getUserId() {
+    public String getUserId() {
         return userId;
     }
 
-    public void setUserId(Long userId) {
+    public void setUserId(String userId) {
         this.userId = userId;
     }
 

--- a/src/main/java/dev/escalated/models/Contact.java
+++ b/src/main/java/dev/escalated/models/Contact.java
@@ -40,9 +40,12 @@ public class Contact extends BaseEntity {
     @Column(length = 255)
     private String name;
 
-    /** Linked host-app user id once the contact creates an account. */
+    /**
+     * Linked host-app user id once the contact creates an account. Stored as a
+     * string so hosts with UUID/string user primary keys can be linked.
+     */
     @Column(name = "user_id")
-    private Long userId;
+    private String userId;
 
     @Column(columnDefinition = "TEXT")
     private String metadataJson;
@@ -63,11 +66,11 @@ public class Contact extends BaseEntity {
         this.name = name;
     }
 
-    public Long getUserId() {
+    public String getUserId() {
         return userId;
     }
 
-    public void setUserId(Long userId) {
+    public void setUserId(String userId) {
         this.userId = userId;
     }
 

--- a/src/main/resources/db/migration/V1__create_escalated_tables.sql
+++ b/src/main/resources/db/migration/V1__create_escalated_tables.sql
@@ -48,7 +48,7 @@ CREATE TABLE escalated_agent_profiles (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
-    user_id BIGINT,
+    user_id VARCHAR(255),
     is_active BOOLEAN NOT NULL DEFAULT TRUE,
     is_available BOOLEAN NOT NULL DEFAULT TRUE,
     avatar VARCHAR(255),

--- a/src/main/resources/db/migration/V2__create_escalated_contacts.sql
+++ b/src/main/resources/db/migration/V2__create_escalated_contacts.sql
@@ -10,7 +10,7 @@ CREATE TABLE escalated_contacts (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     email VARCHAR(320) NOT NULL,
     name VARCHAR(255),
-    user_id BIGINT,
+    user_id VARCHAR(255),
     metadata_json TEXT,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL,


### PR DESCRIPTION
The Spring port is **partially** affected by the integer-user-id assumption. Its core ticket/assignment logic uses Escalated''s own `BIGINT` agent-profile ids and is unaffected. The only host-user-id touch points are two **optional, currently-unused** link columns typed `Long` / `BIGINT`:

- `AgentProfile.userId` (links an agent profile to a host user)
- `Contact.userId` (links a guest contact to a host user once they sign up)

A host whose user primary key is a UUID/string could not populate these. This widens both to `String` / `VARCHAR(255)`.

## Changes

- `AgentProfile.userId` and `Contact.userId`: `Long` → `String` (field + getter/setter).
- `V1__create_escalated_tables.sql` (agent_profiles) and `V2__create_escalated_contacts.sql` (contacts): `user_id BIGINT` → `user_id VARCHAR(255)`.
- **Unchanged:** `escalated_agent_profiles.id` and `agent_skills.user_id` (the latter is an internal FK to `AgentProfile.id`, not a host user id) stay `BIGINT`. `AgentSkillEntryDto`/`AgentSkill` stay `Long`.

## Notes

- These two columns are not yet written by any business logic, so the type change carries no data-migration risk. The change edits the original create-migrations rather than adding an `ALTER` (the existing migrations use H2/MySQL-flavored DDL and a portable multi-DB `ALTER COLUMN TYPE` isn''t clean); since the package is pre-1.0 and the columns are empty, this is safe — adopters on an older build run `flyway repair`.
- No usages break (verified: the only test reference is `assertNull(contact.getUserId())`).

CI (Gradle) validates build + tests; I don''t have a local JDK to run them here.