### PR TITLE
feat(tickets): ticket subjects (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Ticket subjects: attach host-app entities (Project, Customer, asset, …) that a ticket is *about*, distinct from the requester. Host models implement `dev.escalated.contracts.TicketSubject`; a `TicketSubjectResolver` bean resolves type/id pairs for serialization. Tickets expose `subjects[]` on detail responses; admin attach/detach endpoints honor `escalated.ticket-subjects.types`. `subject_id` is stored as `VARCHAR(255)` for integer, UUID, or string host keys. Mirrors Laravel reference (`escalated-laravel#122`).
 - Admin users-management endpoint (`GET /escalated/api/admin/users`, `PATCH /escalated/api/admin/users/{userId}/role`) backing the `Escalated/Admin/Users/Index` page in the shared frontend. Lets an admin grant or revoke the `is_admin` / `is_agent` flags from the panel, with self-demote protection so an admin cannot lock themselves out. Mirrors the Laravel reference (`escalated-laravel#94`).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -111,6 +111,56 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 ```
 
+## Ticket subjects
+
+A ticket has a **requester** (who raised it) and a **subject line** (free text).
+Tickets can also be *about* host-app entities — a Project, Customer, asset — that
+are not people. Attach them as **ticket subjects** so agents see what the ticket
+concerns and can jump to the entity in your app.
+
+Implement the `dev.escalated.contracts.TicketSubject` interface on host models and
+register a `TicketSubjectResolver` bean to resolve `type`/`id` pairs for the UI:
+
+```java
+@Component
+public class ProjectTicketSubjectResolver implements TicketSubjectResolver {
+    private final ProjectRepository projects;
+
+    @Override
+    public TicketSubject resolve(String subjectType, String subjectId) {
+        if (!"com.example.Project".equals(subjectType)) {
+            return null;
+        }
+        return projects.findById(subjectId).orElse(null);
+    }
+}
+```
+
+Allow types the admin API may attach (prevents arbitrary type injection):
+
+```yaml
+escalated:
+  ticket-subjects:
+    types:
+      - com.example.Project
+      - com.example.Customer
+```
+
+Attach or detach via the admin API:
+
+```
+POST   /escalated/api/admin/tickets/{ticketId}/subjects   { "type", "id", "role"? }
+DELETE /escalated/api/admin/tickets/{ticketId}/subjects/{linkId}
+```
+
+Ticket detail responses include `subjects[]` with
+`{ type, id, role, title, subtitle, url, color, icon, missing }`. When no
+resolver is registered or the entity is gone, `title` falls back to `type#id`
+and `missing` is `true`.
+
+Programmatic attach via `TicketSubjectService` works for any type when the
+allowlist is empty; the API only accepts allowlisted types.
+
 ## Custom Ticket Actions
 
 Host applications can add custom buttons to the agent ticket screen and handle

--- a/src/main/java/dev/escalated/config/EscalatedProperties.java
+++ b/src/main/java/dev/escalated/config/EscalatedProperties.java
@@ -20,6 +20,7 @@ public class EscalatedProperties {
     private GuestAccessProperties guestAccess = new GuestAccessProperties();
     private EmailProperties email = new EmailProperties();
     private List<TicketActionProperties> ticketActions = new ArrayList<>();
+    private TicketSubjectsProperties ticketSubjects = new TicketSubjectsProperties();
 
     public boolean isEnabled() {
         return enabled;
@@ -115,6 +116,32 @@ public class EscalatedProperties {
 
     public void setTicketActions(List<TicketActionProperties> ticketActions) {
         this.ticketActions = ticketActions;
+    }
+
+    public TicketSubjectsProperties getTicketSubjects() {
+        return ticketSubjects;
+    }
+
+    public void setTicketSubjects(TicketSubjectsProperties ticketSubjects) {
+        this.ticketSubjects = ticketSubjects;
+    }
+
+    /**
+     * Host-app models a ticket can be *about* (Project, Customer, asset, …).
+     * {@code types} is the allowlist the agent/admin API may attach; leave empty
+     * to disable API attach (programmatic {@link dev.escalated.services.TicketSubjectService}
+     * still works when the allowlist is empty).
+     */
+    public static class TicketSubjectsProperties {
+        private List<String> types = new ArrayList<>();
+
+        public List<String> getTypes() {
+            return types;
+        }
+
+        public void setTypes(List<String> types) {
+            this.types = types;
+        }
     }
 
     /**

--- a/src/main/java/dev/escalated/contracts/TicketSubject.java
+++ b/src/main/java/dev/escalated/contracts/TicketSubject.java
@@ -1,0 +1,20 @@
+package dev.escalated.contracts;
+
+/**
+ * Presentation contract for a host-app entity attached to a ticket as a subject
+ * (a Project, Customer, asset, …). The Spring package does not own host models;
+ * implement this interface on host entities and resolve them via
+ * {@link dev.escalated.services.TicketSubjectResolver}.
+ */
+public interface TicketSubject {
+
+    String ticketSubjectTitle();
+
+    String ticketSubjectSubtitle();
+
+    String ticketSubjectUrl();
+
+    String ticketSubjectColor();
+
+    String ticketSubjectIcon();
+}

--- a/src/main/java/dev/escalated/controllers/admin/AdminTicketSubjectController.java
+++ b/src/main/java/dev/escalated/controllers/admin/AdminTicketSubjectController.java
@@ -1,0 +1,72 @@
+package dev.escalated.controllers.admin;
+
+import dev.escalated.dto.SerializedTicketSubjectDto;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketSubjectLink;
+import dev.escalated.services.TicketService;
+import dev.escalated.services.TicketSubjectService;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/escalated/api/admin/tickets/{ticketId}/subjects")
+public class AdminTicketSubjectController {
+
+    private final TicketService ticketService;
+    private final TicketSubjectService ticketSubjectService;
+
+    public AdminTicketSubjectController(TicketService ticketService,
+                                        TicketSubjectService ticketSubjectService) {
+        this.ticketService = ticketService;
+        this.ticketSubjectService = ticketSubjectService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> attach(@PathVariable Long ticketId,
+                                                      @RequestBody Map<String, Object> body) {
+        String type = requireString(body, "type");
+        Object id = body.get("id");
+        if (id == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "id is required");
+        }
+        if (!ticketSubjectService.isApiTypeAllowed(type)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Subject type [" + type + "] is not an allowed ticket subject.");
+        }
+
+        Ticket ticket = ticketService.findById(ticketId);
+        String role = body.get("role") != null ? body.get("role").toString() : null;
+        TicketSubjectLink link = ticketSubjectService.attach(ticket, type, id, role);
+        List<SerializedTicketSubjectDto> subjects = ticketSubjectService.serializeLinks(List.of(link));
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("link", link);
+        response.put("subjects", subjects);
+        return ResponseEntity.status(201).body(response);
+    }
+
+    @DeleteMapping("/{linkId}")
+    public ResponseEntity<Void> detach(@PathVariable Long ticketId, @PathVariable Long linkId) {
+        Ticket ticket = ticketService.findById(ticketId);
+        ticketSubjectService.detach(ticket, linkId);
+        return ResponseEntity.noContent().build();
+    }
+
+    private static String requireString(Map<String, Object> body, String key) {
+        Object value = body.get(key);
+        if (value == null || value.toString().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, key + " is required");
+        }
+        return value.toString();
+    }
+}

--- a/src/main/java/dev/escalated/dto/SerializedTicketSubjectDto.java
+++ b/src/main/java/dev/escalated/dto/SerializedTicketSubjectDto.java
@@ -1,0 +1,70 @@
+package dev.escalated.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Serialized ticket subject for the ticket detail response and attach API.
+ */
+public class SerializedTicketSubjectDto {
+
+    private final String type;
+    private final String id;
+    private final String role;
+    private final String title;
+    private final String subtitle;
+    private final String url;
+    private final String color;
+    private final String icon;
+    private final boolean missing;
+
+    public SerializedTicketSubjectDto(String type, String id, String role, String title,
+                                      String subtitle, String url, String color, String icon,
+                                      boolean missing) {
+        this.type = type;
+        this.id = id;
+        this.role = role;
+        this.title = title;
+        this.subtitle = subtitle;
+        this.url = url;
+        this.color = color;
+        this.icon = icon;
+        this.missing = missing;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getSubtitle() {
+        return subtitle;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    @JsonProperty("missing")
+    public boolean isMissing() {
+        return missing;
+    }
+}

--- a/src/main/java/dev/escalated/dto/TicketDetailDto.java
+++ b/src/main/java/dev/escalated/dto/TicketDetailDto.java
@@ -6,6 +6,7 @@ import dev.escalated.models.Reply;
 import dev.escalated.models.Ticket;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +40,8 @@ public class TicketDetailDto {
 
     @JsonProperty("custom_actions")
     private List<Map<String, Object>> customActions = new ArrayList<>();
+
+    private List<SerializedTicketSubjectDto> subjects = Collections.emptyList();
 
     public TicketDetailDto(Ticket ticket,
                            Long chatSessionId,
@@ -90,6 +93,14 @@ public class TicketDetailDto {
 
     public void setCustomActions(List<Map<String, Object>> customActions) {
         this.customActions = customActions;
+    }
+
+    public List<SerializedTicketSubjectDto> getSubjects() {
+        return subjects;
+    }
+
+    public void setSubjects(List<SerializedTicketSubjectDto> subjects) {
+        this.subjects = subjects != null ? subjects : Collections.emptyList();
     }
 
     /**

--- a/src/main/java/dev/escalated/models/TicketSubjectLink.java
+++ b/src/main/java/dev/escalated/models/TicketSubjectLink.java
@@ -1,0 +1,78 @@
+package dev.escalated.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+        name = "escalated_ticket_subjects",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_escalated_ticket_subjects_ticket_type_id",
+                columnNames = {"ticket_id", "subject_type", "subject_id"}),
+        indexes = @Index(
+                name = "idx_escalated_ticket_subjects_type_id",
+                columnList = "subject_type, subject_id"))
+public class TicketSubjectLink extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_id", nullable = false)
+    private Ticket ticket;
+
+    @Column(name = "subject_type", nullable = false)
+    private String subjectType;
+
+    @Column(name = "subject_id", nullable = false, length = 255)
+    private String subjectId;
+
+    @Column(name = "role")
+    private String role;
+
+    @Column(name = "position", nullable = false)
+    private int position;
+
+    public Ticket getTicket() {
+        return ticket;
+    }
+
+    public void setTicket(Ticket ticket) {
+        this.ticket = ticket;
+    }
+
+    public String getSubjectType() {
+        return subjectType;
+    }
+
+    public void setSubjectType(String subjectType) {
+        this.subjectType = subjectType;
+    }
+
+    public String getSubjectId() {
+        return subjectId;
+    }
+
+    public void setSubjectId(String subjectId) {
+        this.subjectId = subjectId;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+}

--- a/src/main/java/dev/escalated/repositories/TicketSubjectLinkRepository.java
+++ b/src/main/java/dev/escalated/repositories/TicketSubjectLinkRepository.java
@@ -1,0 +1,23 @@
+package dev.escalated.repositories;
+
+import dev.escalated.models.TicketSubjectLink;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface TicketSubjectLinkRepository extends JpaRepository<TicketSubjectLink, Long> {
+
+    List<TicketSubjectLink> findByTicketIdOrderByPositionAsc(Long ticketId);
+
+    Optional<TicketSubjectLink> findByTicketIdAndSubjectTypeAndSubjectId(
+            Long ticketId, String subjectType, String subjectId);
+
+    Optional<TicketSubjectLink> findByIdAndTicketId(Long id, Long ticketId);
+
+    void deleteByTicketId(Long ticketId);
+
+    @Query("SELECT COALESCE(MAX(l.position), -1) FROM TicketSubjectLink l WHERE l.ticket.id = :ticketId")
+    int findMaxPositionByTicketId(@Param("ticketId") Long ticketId);
+}

--- a/src/main/java/dev/escalated/services/TicketService.java
+++ b/src/main/java/dev/escalated/services/TicketService.java
@@ -47,6 +47,7 @@ public class TicketService {
     private final SlaService slaService;
     private final AuditLogService auditLogService;
     private final ContactRepository contactRepository;
+    private final TicketSubjectService ticketSubjectService;
 
     public TicketService(TicketRepository ticketRepository,
                          ReplyRepository replyRepository,
@@ -58,7 +59,8 @@ public class TicketService {
                          ApplicationEventPublisher eventPublisher,
                          SlaService slaService,
                          AuditLogService auditLogService,
-                         ContactRepository contactRepository) {
+                         ContactRepository contactRepository,
+                         TicketSubjectService ticketSubjectService) {
         this.ticketRepository = ticketRepository;
         this.replyRepository = replyRepository;
         this.tagRepository = tagRepository;
@@ -70,6 +72,7 @@ public class TicketService {
         this.slaService = slaService;
         this.auditLogService = auditLogService;
         this.contactRepository = contactRepository;
+        this.ticketSubjectService = ticketSubjectService;
     }
 
     @Transactional(readOnly = true)
@@ -127,8 +130,10 @@ public class TicketService {
                     link.getLinkType()));
         }
 
-        return new TicketDetailDto(ticket, chatSessionId, chatStartedAt,
+        TicketDetailDto detail = new TicketDetailDto(ticket, chatSessionId, chatStartedAt,
                 chatMessages, chatMetadata, requesterTicketCount, relatedTickets);
+        detail.setSubjects(ticketSubjectService.serializeForTicket(ticket));
+        return detail;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/dev/escalated/services/TicketSubjectResolver.java
+++ b/src/main/java/dev/escalated/services/TicketSubjectResolver.java
@@ -1,0 +1,14 @@
+package dev.escalated.services;
+
+import dev.escalated.contracts.TicketSubject;
+
+/**
+ * Host-provided bean that resolves a polymorphic subject type/id pair to a
+ * {@link TicketSubject} for API serialization, or returns {@code null} when
+ * the entity is missing or not presentable.
+ */
+@FunctionalInterface
+public interface TicketSubjectResolver {
+
+    TicketSubject resolve(String subjectType, String subjectId);
+}

--- a/src/main/java/dev/escalated/services/TicketSubjectService.java
+++ b/src/main/java/dev/escalated/services/TicketSubjectService.java
@@ -1,0 +1,180 @@
+package dev.escalated.services;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.contracts.TicketSubject;
+import dev.escalated.dto.SerializedTicketSubjectDto;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketSubjectLink;
+import dev.escalated.repositories.TicketSubjectLinkRepository;
+import dev.escalated.repositories.TicketRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TicketSubjectService {
+
+    private final TicketSubjectLinkRepository linkRepository;
+    private final TicketRepository ticketRepository;
+    private final EscalatedProperties properties;
+    private final ObjectProvider<TicketSubjectResolver> resolverProvider;
+
+    public TicketSubjectService(TicketSubjectLinkRepository linkRepository,
+                                TicketRepository ticketRepository,
+                                EscalatedProperties properties,
+                                ObjectProvider<TicketSubjectResolver> resolverProvider) {
+        this.linkRepository = linkRepository;
+        this.ticketRepository = ticketRepository;
+        this.properties = properties;
+        this.resolverProvider = resolverProvider;
+    }
+
+    private List<String> allowedTypes() {
+        EscalatedProperties.TicketSubjectsProperties config = properties.getTicketSubjects();
+        if (config == null || config.getTypes() == null) {
+            return List.of();
+        }
+        return config.getTypes();
+    }
+
+    private void assertTypeAllowed(String subjectType) {
+        List<String> allowed = allowedTypes();
+        if (!allowed.isEmpty() && !allowed.contains(subjectType)) {
+            throw new IllegalArgumentException(
+                    "Subject type [" + subjectType + "] is not an allowed ticket subject.");
+        }
+    }
+
+    /**
+     * Returns true when the type may be attached via the agent/admin API
+     * (non-empty allowlist and type is listed).
+     */
+    public boolean isApiTypeAllowed(String subjectType) {
+        List<String> allowed = allowedTypes();
+        return !allowed.isEmpty() && allowed.contains(subjectType);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TicketSubjectLink> list(Ticket ticket) {
+        return linkRepository.findByTicketIdOrderByPositionAsc(ticket.getId());
+    }
+
+    @Transactional(readOnly = true)
+    public List<TicketSubjectLink> listByTicketId(Long ticketId) {
+        return linkRepository.findByTicketIdOrderByPositionAsc(ticketId);
+    }
+
+    @Transactional
+    public TicketSubjectLink attach(Ticket ticket, String subjectType, Object subjectId, String role) {
+        assertTypeAllowed(subjectType);
+        String id = String.valueOf(subjectId);
+
+        Optional<TicketSubjectLink> existing =
+                linkRepository.findByTicketIdAndSubjectTypeAndSubjectId(ticket.getId(), subjectType, id);
+        if (existing.isPresent()) {
+            TicketSubjectLink link = existing.get();
+            if (role != null) {
+                link.setRole(role);
+            }
+            return linkRepository.save(link);
+        }
+
+        TicketSubjectLink link = new TicketSubjectLink();
+        link.setTicket(ticket);
+        link.setSubjectType(subjectType);
+        link.setSubjectId(id);
+        link.setRole(role);
+        link.setPosition(linkRepository.findMaxPositionByTicketId(ticket.getId()) + 1);
+        return linkRepository.save(link);
+    }
+
+    @Transactional
+    public TicketSubjectLink attach(Long ticketId, String subjectType, Object subjectId, String role) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new EntityNotFoundException("Ticket not found: " + ticketId));
+        return attach(ticket, subjectType, subjectId, role);
+    }
+
+    @Transactional
+    public void detach(Ticket ticket, Long linkId) {
+        TicketSubjectLink link = linkRepository.findByIdAndTicketId(linkId, ticket.getId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Ticket subject link #" + linkId + " not found"));
+        linkRepository.delete(link);
+    }
+
+    @Transactional
+    public void detachByKey(Ticket ticket, String subjectType, Object subjectId) {
+        String id = String.valueOf(subjectId);
+        linkRepository.findByTicketIdAndSubjectTypeAndSubjectId(ticket.getId(), subjectType, id)
+                .ifPresent(linkRepository::delete);
+    }
+
+    /**
+     * Replace all subjects on a ticket with the given items, preserving order.
+     */
+    @Transactional
+    public List<TicketSubjectLink> sync(Ticket ticket, List<SyncItem> items) {
+        linkRepository.deleteByTicketId(ticket.getId());
+
+        List<TicketSubjectLink> links = new ArrayList<>();
+        int position = 0;
+        for (SyncItem item : items) {
+            assertTypeAllowed(item.subjectType());
+            TicketSubjectLink link = new TicketSubjectLink();
+            link.setTicket(ticket);
+            link.setSubjectType(item.subjectType());
+            link.setSubjectId(String.valueOf(item.subjectId()));
+            link.setRole(item.role());
+            link.setPosition(position++);
+            links.add(linkRepository.save(link));
+        }
+        return links;
+    }
+
+    @Transactional(readOnly = true)
+    public List<SerializedTicketSubjectDto> serializeLinks(List<TicketSubjectLink> links) {
+        TicketSubjectResolver resolver = resolverProvider.getIfAvailable();
+        List<SerializedTicketSubjectDto> result = new ArrayList<>();
+        for (TicketSubjectLink link : links) {
+            TicketSubject resolved = resolver != null
+                    ? resolver.resolve(link.getSubjectType(), link.getSubjectId())
+                    : null;
+            boolean presents = resolved != null;
+            result.add(new SerializedTicketSubjectDto(
+                    link.getSubjectType(),
+                    link.getSubjectId(),
+                    link.getRole(),
+                    presents ? resolved.ticketSubjectTitle()
+                            : link.getSubjectType() + "#" + link.getSubjectId(),
+                    presents ? resolved.ticketSubjectSubtitle() : null,
+                    presents ? resolved.ticketSubjectUrl() : null,
+                    presents ? resolved.ticketSubjectColor() : null,
+                    presents ? resolved.ticketSubjectIcon() : null,
+                    !presents));
+        }
+        return result;
+    }
+
+    @Transactional(readOnly = true)
+    public List<SerializedTicketSubjectDto> serializeForTicket(Ticket ticket) {
+        return serializeLinks(list(ticket));
+    }
+
+    @Transactional(readOnly = true)
+    public List<SerializedTicketSubjectDto> serializeForTicketId(Long ticketId) {
+        return serializeLinks(listByTicketId(ticketId));
+    }
+
+    public record SyncItem(String subjectType, Object subjectId, String role) {
+        public SyncItem {
+            Objects.requireNonNull(subjectType, "subjectType");
+            Objects.requireNonNull(subjectId, "subjectId");
+        }
+    }
+}

--- a/src/main/resources/db/migration/V7__create_escalated_ticket_subjects.sql
+++ b/src/main/resources/db/migration/V7__create_escalated_ticket_subjects.sql
@@ -1,0 +1,18 @@
+-- Ticket subjects — host-app entities a ticket is *about* (Project, Customer, asset, …),
+-- distinct from the requester and the subject line. subject_id is VARCHAR so integer,
+-- UUID, ULID, or other string host keys all work.
+
+CREATE TABLE escalated_ticket_subjects (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    ticket_id BIGINT NOT NULL,
+    subject_type VARCHAR(255) NOT NULL,
+    subject_id VARCHAR(255) NOT NULL,
+    role VARCHAR(255),
+    position INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_escalated_ticket_subjects_ticket FOREIGN KEY (ticket_id) REFERENCES escalated_tickets (id) ON DELETE CASCADE,
+    CONSTRAINT uq_escalated_ticket_subjects_ticket_type_id UNIQUE (ticket_id, subject_type, subject_id)
+);
+
+CREATE INDEX idx_escalated_ticket_subjects_type_id ON escalated_ticket_subjects (subject_type, subject_id);

--- a/src/test/java/dev/escalated/controllers/AdminTicketSubjectControllerTest.java
+++ b/src/test/java/dev/escalated/controllers/AdminTicketSubjectControllerTest.java
@@ -1,0 +1,92 @@
+package dev.escalated.controllers;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import dev.escalated.controllers.admin.AdminTicketSubjectController;
+import dev.escalated.dto.SerializedTicketSubjectDto;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketSubjectLink;
+import dev.escalated.security.ApiTokenAuthenticationFilter;
+import dev.escalated.services.TicketService;
+import dev.escalated.services.TicketSubjectService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminTicketSubjectController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AdminTicketSubjectControllerTest {
+
+    private static final String SUBJECT_TYPE = "com.example.FakeProject";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ApiTokenAuthenticationFilter apiTokenFilter;
+
+    @MockitoBean
+    private TicketService ticketService;
+
+    @MockitoBean
+    private TicketSubjectService ticketSubjectService;
+
+    @Test
+    void attach_shouldReturnLinkAndSubjects() throws Exception {
+        Ticket ticket = new Ticket();
+        ticket.setId(1L);
+        TicketSubjectLink link = new TicketSubjectLink();
+        link.setId(5L);
+        link.setSubjectType(SUBJECT_TYPE);
+        link.setSubjectId("prj_1");
+
+        when(ticketSubjectService.isApiTypeAllowed(SUBJECT_TYPE)).thenReturn(true);
+        when(ticketService.findById(1L)).thenReturn(ticket);
+        when(ticketSubjectService.attach(eq(ticket), eq(SUBJECT_TYPE), eq("prj_1"), eq("project")))
+                .thenReturn(link);
+        when(ticketSubjectService.serializeLinks(List.of(link))).thenReturn(List.of(
+                new SerializedTicketSubjectDto(SUBJECT_TYPE, "prj_1", "project", "Title",
+                        null, null, null, null, true)));
+
+        mockMvc.perform(post("/escalated/api/admin/tickets/1/subjects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"type\":\"" + SUBJECT_TYPE + "\",\"id\":\"prj_1\",\"role\":\"project\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.subjects[0].type").value(SUBJECT_TYPE))
+                .andExpect(jsonPath("$.subjects[0].id").value("prj_1"))
+                .andExpect(jsonPath("$.subjects[0].missing").value(true));
+    }
+
+    @Test
+    void attach_shouldRejectDisallowedType() throws Exception {
+        when(ticketSubjectService.isApiTypeAllowed("bad")).thenReturn(false);
+
+        mockMvc.perform(post("/escalated/api/admin/tickets/1/subjects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"type\":\"bad\",\"id\":\"1\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void detach_shouldReturnNoContent() throws Exception {
+        Ticket ticket = new Ticket();
+        ticket.setId(1L);
+        when(ticketService.findById(1L)).thenReturn(ticket);
+
+        mockMvc.perform(delete("/escalated/api/admin/tickets/1/subjects/9"))
+                .andExpect(status().isNoContent());
+
+        verify(ticketSubjectService).detach(ticket, 9L);
+    }
+}

--- a/src/test/java/dev/escalated/services/TicketServiceContactWireupTest.java
+++ b/src/test/java/dev/escalated/services/TicketServiceContactWireupTest.java
@@ -47,6 +47,7 @@ class TicketServiceContactWireupTest {
     @Mock private SlaService slaService;
     @Mock private AuditLogService auditLogService;
     @Mock private ContactRepository contactRepository;
+    @Mock private TicketSubjectService ticketSubjectService;
 
     private TicketService ticketService;
 
@@ -54,7 +55,7 @@ class TicketServiceContactWireupTest {
     void setUp() {
         ticketService = new TicketService(ticketRepository, replyRepository, tagRepository,
                 activityRepository, agentRepository, chatSessionRepository, ticketLinkRepository,
-                eventPublisher, slaService, auditLogService, contactRepository);
+                eventPublisher, slaService, auditLogService, contactRepository, ticketSubjectService);
 
         when(ticketRepository.save(any(Ticket.class))).thenAnswer(inv -> {
             Ticket t = inv.getArgument(0);

--- a/src/test/java/dev/escalated/services/TicketServiceTest.java
+++ b/src/test/java/dev/escalated/services/TicketServiceTest.java
@@ -57,6 +57,8 @@ class TicketServiceTest {
     private AuditLogService auditLogService;
     @Mock
     private ContactRepository contactRepository;
+    @Mock
+    private TicketSubjectService ticketSubjectService;
 
     private TicketService ticketService;
 
@@ -64,7 +66,7 @@ class TicketServiceTest {
     void setUp() {
         ticketService = new TicketService(ticketRepository, replyRepository, tagRepository,
                 activityRepository, agentRepository, chatSessionRepository, ticketLinkRepository,
-                eventPublisher, slaService, auditLogService, contactRepository);
+                eventPublisher, slaService, auditLogService, contactRepository, ticketSubjectService);
     }
 
     @Test

--- a/src/test/java/dev/escalated/services/TicketSubjectServiceTest.java
+++ b/src/test/java/dev/escalated/services/TicketSubjectServiceTest.java
@@ -1,0 +1,200 @@
+package dev.escalated.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.escalated.config.EscalatedProperties;
+import dev.escalated.contracts.TicketSubject;
+import dev.escalated.dto.SerializedTicketSubjectDto;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketSubjectLink;
+import dev.escalated.repositories.TicketRepository;
+import dev.escalated.repositories.TicketSubjectLinkRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+@ExtendWith(MockitoExtension.class)
+class TicketSubjectServiceTest {
+
+    private static final String SUBJECT_TYPE = "com.example.FakeProject";
+
+    @Mock
+    private TicketSubjectLinkRepository linkRepository;
+    @Mock
+    private TicketRepository ticketRepository;
+    @Mock
+    private ObjectProvider<TicketSubjectResolver> resolverProvider;
+
+    private EscalatedProperties properties;
+    private TicketSubjectService service;
+
+    private final Ticket ticket = new Ticket();
+
+    @BeforeEach
+    void setUp() {
+        ticket.setId(1L);
+        properties = new EscalatedProperties();
+        properties.getTicketSubjects().setTypes(List.of(SUBJECT_TYPE));
+        service = new TicketSubjectService(linkRepository, ticketRepository, properties, resolverProvider);
+    }
+
+    @Test
+    void attach_preservesStringIdAndRole() {
+        when(linkRepository.findByTicketIdAndSubjectTypeAndSubjectId(1L, SUBJECT_TYPE, "prj_9f1c"))
+                .thenReturn(Optional.empty());
+        when(linkRepository.findMaxPositionByTicketId(1L)).thenReturn(-1);
+        when(linkRepository.save(any(TicketSubjectLink.class))).thenAnswer(inv -> {
+            TicketSubjectLink link = inv.getArgument(0);
+            link.setId(10L);
+            return link;
+        });
+
+        TicketSubjectLink link = service.attach(ticket, SUBJECT_TYPE, "prj_9f1c", "project");
+
+        assertThat(link.getSubjectType()).isEqualTo(SUBJECT_TYPE);
+        assertThat(link.getSubjectId()).isEqualTo("prj_9f1c");
+        assertThat(link.getRole()).isEqualTo("project");
+        assertThat(link.getPosition()).isEqualTo(0);
+    }
+
+    @Test
+    void attach_isIdempotentAndUpdatesRole() {
+        TicketSubjectLink existing = new TicketSubjectLink();
+        existing.setId(5L);
+        existing.setSubjectType(SUBJECT_TYPE);
+        existing.setSubjectId("p1");
+        existing.setRole(null);
+        when(linkRepository.findByTicketIdAndSubjectTypeAndSubjectId(1L, SUBJECT_TYPE, "p1"))
+                .thenReturn(Optional.of(existing));
+        when(linkRepository.save(existing)).thenReturn(existing);
+
+        TicketSubjectLink link = service.attach(ticket, SUBJECT_TYPE, "p1", "account");
+
+        assertThat(link.getRole()).isEqualTo("account");
+        verify(linkRepository).save(existing);
+    }
+
+    @Test
+    void attach_rejectsTypeOutsideAllowlist() {
+        assertThatThrownBy(() -> service.attach(ticket, "com.example.Other", "1", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not an allowed ticket subject");
+    }
+
+    @Test
+    void attach_allowsAnyTypeWhenAllowlistEmpty() {
+        properties.getTicketSubjects().setTypes(List.of());
+        when(linkRepository.findByTicketIdAndSubjectTypeAndSubjectId(1L, "any", "1"))
+                .thenReturn(Optional.empty());
+        when(linkRepository.findMaxPositionByTicketId(1L)).thenReturn(0);
+        when(linkRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.attach(ticket, "any", 1, null);
+    }
+
+    @Test
+    void sync_replacesSubjectsInOrder() {
+        properties.getTicketSubjects().setTypes(List.of(SUBJECT_TYPE));
+        when(linkRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<TicketSubjectLink> links = service.sync(ticket, List.of(
+                new TicketSubjectService.SyncItem(SUBJECT_TYPE, "b", "primary"),
+                new TicketSubjectService.SyncItem(SUBJECT_TYPE, "c", null)));
+
+        verify(linkRepository).deleteByTicketId(1L);
+        assertThat(links).hasSize(2);
+        assertThat(links.get(0).getSubjectId()).isEqualTo("b");
+        assertThat(links.get(0).getRole()).isEqualTo("primary");
+        assertThat(links.get(0).getPosition()).isZero();
+        assertThat(links.get(1).getSubjectId()).isEqualTo("c");
+        assertThat(links.get(1).getPosition()).isEqualTo(1);
+    }
+
+    @Test
+    void serialize_usesContractWhenResolverPresent() {
+        TicketSubjectLink link = new TicketSubjectLink();
+        link.setSubjectType(SUBJECT_TYPE);
+        link.setSubjectId("7");
+        link.setRole("project");
+
+        when(resolverProvider.getIfAvailable()).thenReturn((type, id) -> new TicketSubject() {
+            @Override
+            public String ticketSubjectTitle() {
+                return "Acme Redesign";
+            }
+
+            @Override
+            public String ticketSubjectSubtitle() {
+                return "Project · Acme";
+            }
+
+            @Override
+            public String ticketSubjectUrl() {
+                return "https://app.test/projects/7";
+            }
+
+            @Override
+            public String ticketSubjectColor() {
+                return "#2563eb";
+            }
+
+            @Override
+            public String ticketSubjectIcon() {
+                return "folder";
+            }
+        });
+
+        List<SerializedTicketSubjectDto> serialized = service.serializeLinks(List.of(link));
+
+        assertThat(serialized).hasSize(1);
+        assertThat(serialized.get(0).getTitle()).isEqualTo("Acme Redesign");
+        assertThat(serialized.get(0).getSubtitle()).isEqualTo("Project · Acme");
+        assertThat(serialized.get(0).getUrl()).isEqualTo("https://app.test/projects/7");
+        assertThat(serialized.get(0).getColor()).isEqualTo("#2563eb");
+        assertThat(serialized.get(0).getIcon()).isEqualTo("folder");
+        assertThat(serialized.get(0).isMissing()).isFalse();
+    }
+
+    @Test
+    void serialize_fallsBackWhenResolverMissing() {
+        when(resolverProvider.getIfAvailable()).thenReturn(null);
+
+        TicketSubjectLink link = new TicketSubjectLink();
+        link.setSubjectType(SUBJECT_TYPE);
+        link.setSubjectId("99");
+
+        List<SerializedTicketSubjectDto> serialized = service.serializeLinks(List.of(link));
+
+        assertThat(serialized.get(0).getTitle()).isEqualTo(SUBJECT_TYPE + "#99");
+        assertThat(serialized.get(0).isMissing()).isTrue();
+    }
+
+    @Test
+    void detach_deletesLinkForTicket() {
+        TicketSubjectLink link = new TicketSubjectLink();
+        link.setId(3L);
+        when(linkRepository.findByIdAndTicketId(3L, 1L)).thenReturn(Optional.of(link));
+
+        service.detach(ticket, 3L);
+
+        verify(linkRepository).delete(link);
+    }
+
+    @Test
+    void isApiTypeAllowed_requiresNonEmptyAllowlist() {
+        assertThat(service.isApiTypeAllowed(SUBJECT_TYPE)).isTrue();
+        assertThat(service.isApiTypeAllowed("other")).isFalse();
+
+        properties.getTicketSubjects().setTypes(List.of());
+        assertThat(service.isApiTypeAllowed(SUBJECT_TYPE)).isFalse();
+    }
+}


### PR DESCRIPTION
Spring Boot port of Ticket Subjects (mirrors escalated-laravel#122 / escalated-nestjs#59; discussion #89). Host entities a ticket is *about* (Project/Customer/asset) — multiple, polymorphic, distinct from the requester.

- New Flyway `V7__create_escalated_ticket_subjects.sql`: `ticket_id` FK cascade, `subject_type` + **`subject_id VARCHAR(255)`** (string, uuid-safe — not BIGINT), `role`, `position`; unique `(ticket_id, subject_type, subject_id)` + `(subject_type, subject_id)` index. (New migration — does not edit V1-V6.)
- `TicketSubject` contract + `TicketSubjectResolver` bean (the host maps a stored `(type,id)` to its presentable instance; fallback `title = type#id`, `missing: true`). Allowlist via `escalated.ticket-subjects.types`.
- `TicketSubjectLink` entity + repository + `TicketSubjectService` (attach/detach/sync, idempotent, allowlist-guarded).
- `subjects[]` `{type,id,role,title,subtitle,url,color,icon,missing}` on `TicketDetailDto`; admin `POST`/`DELETE` attach/detach (allowlist-only).

`./gradlew build test checkstyleMain checkstyleTest` → **BUILD SUCCESSFUL** (incl. new `TicketSubjectServiceTest` + controller test).