### PR TITLE
fix(newsletter): UUID-safe user-id columns (String/VARCHAR) on newsletter

### DIFF
--- a/src/main/java/dev/escalated/models/newsletter/Newsletter.java
+++ b/src/main/java/dev/escalated/models/newsletter/Newsletter.java
@@ -59,10 +59,10 @@ public class Newsletter extends BaseEntity {
     private Instant sentAt;
 
     @Column(name = "created_by")
-    private Long createdBy;
+    private String createdBy;
 
     @Column(name = "sent_by")
-    private Long sentBy;
+    private String sentBy;
 
     @Column(name = "summary_total", nullable = false)
     private int summaryTotal = 0;

--- a/src/main/java/dev/escalated/models/newsletter/NewsletterList.java
+++ b/src/main/java/dev/escalated/models/newsletter/NewsletterList.java
@@ -34,7 +34,7 @@ public class NewsletterList extends BaseEntity {
     private String filterJson;
 
     @Column(name = "created_by")
-    private Long createdBy;
+    private String createdBy;
 
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
@@ -44,6 +44,6 @@ public class NewsletterList extends BaseEntity {
     public void setKind(String kind) { this.kind = kind; }
     public String getFilterJson() { return filterJson; }
     public void setFilterJson(String filterJson) { this.filterJson = filterJson; }
-    public Long getCreatedBy() { return createdBy; }
-    public void setCreatedBy(Long createdBy) { this.createdBy = createdBy; }
+    public String getCreatedBy() { return createdBy; }
+    public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
 }

--- a/src/main/java/dev/escalated/models/newsletter/NewsletterListMember.java
+++ b/src/main/java/dev/escalated/models/newsletter/NewsletterListMember.java
@@ -26,7 +26,7 @@ public class NewsletterListMember extends BaseEntity {
     private Instant addedAt = Instant.now();
 
     @Column(name = "added_by")
-    private Long addedBy;
+    private String addedBy;
 
     public Long getListId() { return listId; }
     public void setListId(Long listId) { this.listId = listId; }
@@ -34,6 +34,6 @@ public class NewsletterListMember extends BaseEntity {
     public void setContactId(Long contactId) { this.contactId = contactId; }
     public Instant getAddedAt() { return addedAt; }
     public void setAddedAt(Instant addedAt) { this.addedAt = addedAt; }
-    public Long getAddedBy() { return addedBy; }
-    public void setAddedBy(Long addedBy) { this.addedBy = addedBy; }
+    public String getAddedBy() { return addedBy; }
+    public void setAddedBy(String addedBy) { this.addedBy = addedBy; }
 }

--- a/src/main/java/dev/escalated/models/newsletter/NewsletterTemplate.java
+++ b/src/main/java/dev/escalated/models/newsletter/NewsletterTemplate.java
@@ -35,7 +35,7 @@ public class NewsletterTemplate extends BaseEntity {
     private String mergeFieldsSchema;
 
     @Column(name = "created_by")
-    private Long createdBy;
+    private String createdBy;
 
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
@@ -47,6 +47,6 @@ public class NewsletterTemplate extends BaseEntity {
     public void setBodyMarkdown(String bodyMarkdown) { this.bodyMarkdown = bodyMarkdown; }
     public String getMergeFieldsSchema() { return mergeFieldsSchema; }
     public void setMergeFieldsSchema(String mergeFieldsSchema) { this.mergeFieldsSchema = mergeFieldsSchema; }
-    public Long getCreatedBy() { return createdBy; }
-    public void setCreatedBy(Long createdBy) { this.createdBy = createdBy; }
+    public String getCreatedBy() { return createdBy; }
+    public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
 }

--- a/src/main/resources/db/migration/V8__create_escalated_newsletters.sql
+++ b/src/main/resources/db/migration/V8__create_escalated_newsletters.sql
@@ -12,7 +12,7 @@ CREATE TABLE escalated_newsletter_lists (
     description TEXT,
     kind VARCHAR(16) NOT NULL DEFAULT 'static',
     filter_json TEXT,
-    created_by BIGINT,
+    created_by VARCHAR(255),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -26,7 +26,7 @@ CREATE TABLE escalated_newsletter_templates (
     subject_template VARCHAR(998),
     body_markdown TEXT NOT NULL,
     merge_fields_schema TEXT,
-    created_by BIGINT,
+    created_by VARCHAR(255),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -38,7 +38,7 @@ CREATE TABLE escalated_newsletter_list_members (
     list_id BIGINT NOT NULL,
     contact_id BIGINT NOT NULL,
     added_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    added_by BIGINT,
+    added_by VARCHAR(255),
     CONSTRAINT uniq_nlm_list_contact UNIQUE (list_id, contact_id),
     CONSTRAINT fk_nlm_list FOREIGN KEY (list_id) REFERENCES escalated_newsletter_lists (id) ON DELETE CASCADE,
     CONSTRAINT fk_nlm_contact FOREIGN KEY (contact_id) REFERENCES escalated_contacts (id) ON DELETE CASCADE
@@ -58,8 +58,8 @@ CREATE TABLE escalated_newsletters (
     status VARCHAR(16) NOT NULL DEFAULT 'draft',
     scheduled_at TIMESTAMP,
     sent_at TIMESTAMP,
-    created_by BIGINT,
-    sent_by BIGINT,
+    created_by VARCHAR(255),
+    sent_by VARCHAR(255),
     summary_total INT NOT NULL DEFAULT 0,
     summary_sent INT NOT NULL DEFAULT 0,
     summary_opened INT NOT NULL DEFAULT 0,


### PR DESCRIPTION
Newsletter `created_by`/`added_by`/`sent_by` were `Long` + `BIGINT` (integer-only), while every other host-user reference uses `String` (`Contact.userId`; `VARCHAR(255)` in V1/V2 migrations). Switches the entity fields/accessors to `String` and the V8 migration's user columns to `VARCHAR(255)`. FK columns (`target_list_id`/`template_id`) stay `BIGINT`. V8 was merged today and is unreleased (tests skip Flyway), so amending it in place is safe. The accessors are never called, so there is no cascade.