### PR TITLE
Add SECURITY.md security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+Security vulnerabilities affecting this package should be reported through the main Escalated security process.
+
+Please review the official Escalated Security Policy:
+
+https://github.com/escalated-dev/escalated/blob/main/SECURITY.md
+
+This repository follows the security disclosure, response, remediation, and supported-version policies defined by the Escalated project.
+
+Please do not disclose security vulnerabilities publicly through GitHub issues, discussions, or pull requests.
+
+Thank you for helping keep the Escalated ecosystem secure.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` pointing vulnerability reports to the main Escalated security policy.

## Test plan
- [x] Verify `SECURITY.md` renders correctly on GitHub
- [x] Confirm link to https://github.com/escalated-dev/escalated/blob/main/SECURITY.md resolves