### PR TITLE
feat(reporting): functional advanced reporting endpoints

### DIFF
--- a/src/main/java/dev/escalated/controllers/admin/AdminReportController.java
+++ b/src/main/java/dev/escalated/controllers/admin/AdminReportController.java
@@ -1,0 +1,73 @@
+package dev.escalated.controllers.admin;
+
+import dev.escalated.dto.reporting.AgentPerformanceReport;
+import dev.escalated.dto.reporting.CsatReport;
+import dev.escalated.dto.reporting.OverviewReport;
+import dev.escalated.dto.reporting.PeriodComparisonReport;
+import dev.escalated.dto.reporting.ResponseTimeReport;
+import dev.escalated.dto.reporting.SlaReport;
+import dev.escalated.dto.reporting.VolumeReport;
+import dev.escalated.services.AdvancedReportingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin-secured analytics endpoints. Sits behind the {@code /escalated/api/**}
+ * security filter chain (token-authenticated) like every other admin
+ * controller, and returns JSON report DTOs produced by
+ * {@link AdvancedReportingService}. The {@code days} query parameter selects
+ * the trailing window (defaults to 30).
+ */
+@RestController
+@RequestMapping("/escalated/api/admin/reports")
+public class AdminReportController {
+
+    private final AdvancedReportingService reporting;
+
+    public AdminReportController(AdvancedReportingService reporting) {
+        this.reporting = reporting;
+    }
+
+    @GetMapping("/overview")
+    public ResponseEntity<OverviewReport> overview(@RequestParam(defaultValue = "30") int days) {
+        return ResponseEntity.ok(reporting.overview(days));
+    }
+
+    @GetMapping("/sla")
+    public ResponseEntity<SlaReport> sla(@RequestParam(defaultValue = "30") int days) {
+        return ResponseEntity.ok(reporting.slaReport(days));
+    }
+
+    @GetMapping("/first-response-time")
+    public ResponseEntity<ResponseTimeReport> firstResponseTime(@RequestParam(defaultValue = "30") int days) {
+        return ResponseEntity.ok(reporting.firstResponseTime(days));
+    }
+
+    @GetMapping("/resolution-time")
+    public ResponseEntity<ResponseTimeReport> resolutionTime(@RequestParam(defaultValue = "30") int days) {
+        return ResponseEntity.ok(reporting.resolutionTime(days));
+    }
+
+    @GetMapping("/csat")
+    public ResponseEntity<CsatReport> csat(@RequestParam(defaultValue = "30") int days) {
+        return ResponseEntity.ok(reporting.csat(days));
+    }
+
+    @GetMapping("/volume")
+    public ResponseEntity<VolumeReport> volume(@RequestParam(defaultValue = "30") int days) {
+        return ResponseEntity.ok(reporting.volume(days));
+    }
+
+    @GetMapping("/agent-performance")
+    public ResponseEntity<AgentPerformanceReport> agentPerformance(@RequestParam(defaultValue = "30") int days) {
+        return ResponseEntity.ok(reporting.agentPerformance(days));
+    }
+
+    @GetMapping("/period-comparison")
+    public ResponseEntity<PeriodComparisonReport> periodComparison(@RequestParam(defaultValue = "30") int days) {
+        return ResponseEntity.ok(reporting.periodComparison(days));
+    }
+}

--- a/src/main/java/dev/escalated/dto/reporting/AgentPerformanceReport.java
+++ b/src/main/java/dev/escalated/dto/reporting/AgentPerformanceReport.java
@@ -1,0 +1,26 @@
+package dev.escalated.dto.reporting;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Ranked agent performance. Each row carries a composite score (resolution
+ * rate, first-response time, CSAT) computed by
+ * {@code AdvancedReportingService.compositeScore}.
+ */
+public record AgentPerformanceReport(
+        @JsonProperty("period_days") int periodDays,
+        List<AgentRow> agents) {
+
+    public record AgentRow(
+            @JsonProperty("agent_id") long agentId,
+            @JsonProperty("agent_name") String agentName,
+            @JsonProperty("total_tickets") long totalTickets,
+            @JsonProperty("resolved_tickets") long resolvedTickets,
+            @JsonProperty("resolution_rate") double resolutionRate,
+            @JsonProperty("avg_response_hours") double avgResponseHours,
+            @JsonProperty("csat_average") double csatAverage,
+            @JsonProperty("composite_score") double compositeScore,
+            int rank) {
+    }
+}

--- a/src/main/java/dev/escalated/dto/reporting/CsatReport.java
+++ b/src/main/java/dev/escalated/dto/reporting/CsatReport.java
@@ -1,0 +1,23 @@
+package dev.escalated.dto.reporting;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Customer satisfaction analytics: average rating, response rate, a breakdown
+ * by rating value, and a per-day trend of average rating.
+ */
+public record CsatReport(
+        @JsonProperty("period_days") int periodDays,
+        double average,
+        @JsonProperty("total_ratings") long totalRatings,
+        @JsonProperty("response_rate") double responseRate,
+        List<ReportSeriesPoint> breakdown,
+        @JsonProperty("over_time") List<TrendPoint> overTime) {
+
+    public record TrendPoint(
+            String date,
+            @JsonProperty("avg_rating") double avgRating,
+            long count) {
+    }
+}

--- a/src/main/java/dev/escalated/dto/reporting/OverviewReport.java
+++ b/src/main/java/dev/escalated/dto/reporting/OverviewReport.java
@@ -1,0 +1,22 @@
+package dev.escalated.dto.reporting;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Headline dashboard metrics for a reporting period: totals, average response
+ * and resolution times, SLA compliance, CSAT, and grouped counts.
+ */
+public record OverviewReport(
+        @JsonProperty("period_days") int periodDays,
+        @JsonProperty("total_tickets") long totalTickets,
+        @JsonProperty("resolved_tickets") long resolvedTickets,
+        @JsonProperty("resolution_rate") double resolutionRate,
+        @JsonProperty("avg_first_response_hours") double avgFirstResponseHours,
+        @JsonProperty("avg_resolution_hours") double avgResolutionHours,
+        @JsonProperty("sla_compliance_rate") double slaComplianceRate,
+        @JsonProperty("csat_average") double csatAverage,
+        @JsonProperty("by_status") List<ReportSeriesPoint> byStatus,
+        @JsonProperty("by_priority") List<ReportSeriesPoint> byPriority,
+        @JsonProperty("by_channel") List<ReportSeriesPoint> byChannel) {
+}

--- a/src/main/java/dev/escalated/dto/reporting/PeriodComparisonReport.java
+++ b/src/main/java/dev/escalated/dto/reporting/PeriodComparisonReport.java
@@ -1,0 +1,16 @@
+package dev.escalated.dto.reporting;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/**
+ * Current period vs. the immediately preceding period of equal length, with
+ * percentage changes computed by
+ * {@code AdvancedReportingService.calculateChanges}.
+ */
+public record PeriodComparisonReport(
+        @JsonProperty("period_days") int periodDays,
+        Map<String, Double> current,
+        Map<String, Double> previous,
+        Map<String, Double> changes) {
+}

--- a/src/main/java/dev/escalated/dto/reporting/ReportSeriesPoint.java
+++ b/src/main/java/dev/escalated/dto/reporting/ReportSeriesPoint.java
@@ -1,0 +1,9 @@
+package dev.escalated.dto.reporting;
+
+/**
+ * A single labelled data point used across reports (status/priority/channel
+ * counts, daily volume, rating breakdowns). Maps directly to the
+ * {@code {"label": ..., "value": ...}} shape the reporting frontend expects.
+ */
+public record ReportSeriesPoint(String label, long value) {
+}

--- a/src/main/java/dev/escalated/dto/reporting/ResponseTimeReport.java
+++ b/src/main/java/dev/escalated/dto/reporting/ResponseTimeReport.java
@@ -1,0 +1,28 @@
+package dev.escalated.dto.reporting;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Response-time analytics reused for both first-response and resolution
+ * reports: a bucketed histogram, percentiles (p50/p75/p90/p95/p99), and a
+ * per-day trend of average hours.
+ */
+public record ResponseTimeReport(
+        @JsonProperty("period_days") int periodDays,
+        @JsonProperty("total_measured") long totalMeasured,
+        @JsonProperty("avg_hours") double avgHours,
+        List<HistogramBucket> distribution,
+        Map<String, Double> percentiles,
+        List<TrendPoint> trend) {
+
+    public record HistogramBucket(String bucket, long count, double percentage) {
+    }
+
+    public record TrendPoint(
+            String date,
+            @JsonProperty("avg_hours") double avgHours,
+            long count) {
+    }
+}

--- a/src/main/java/dev/escalated/dto/reporting/SlaReport.java
+++ b/src/main/java/dev/escalated/dto/reporting/SlaReport.java
@@ -1,0 +1,25 @@
+package dev.escalated.dto.reporting;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * SLA compliance and breach trends over a period, with a per-priority
+ * breakdown of breach rates.
+ */
+public record SlaReport(
+        @JsonProperty("period_days") int periodDays,
+        @JsonProperty("compliance_rate") double complianceRate,
+        @JsonProperty("total_with_sla") long totalWithSla,
+        @JsonProperty("first_response_breaches") long firstResponseBreaches,
+        @JsonProperty("resolution_breaches") long resolutionBreaches,
+        @JsonProperty("total_breaches") long totalBreaches,
+        @JsonProperty("by_priority") List<PriorityBreakdown> byPriority) {
+
+    public record PriorityBreakdown(
+            String priority,
+            long total,
+            long breached,
+            @JsonProperty("breach_rate") double breachRate) {
+    }
+}

--- a/src/main/java/dev/escalated/dto/reporting/VolumeReport.java
+++ b/src/main/java/dev/escalated/dto/reporting/VolumeReport.java
@@ -1,0 +1,16 @@
+package dev.escalated.dto.reporting;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Ticket-volume analytics: a zero-filled daily series plus cohort breakdowns
+ * by priority and channel.
+ */
+public record VolumeReport(
+        @JsonProperty("period_days") int periodDays,
+        @JsonProperty("total_tickets") long totalTickets,
+        List<ReportSeriesPoint> series,
+        @JsonProperty("by_priority") List<ReportSeriesPoint> byPriority,
+        @JsonProperty("by_channel") List<ReportSeriesPoint> byChannel) {
+}

--- a/src/main/java/dev/escalated/repositories/SatisfactionRatingRepository.java
+++ b/src/main/java/dev/escalated/repositories/SatisfactionRatingRepository.java
@@ -1,10 +1,12 @@
 package dev.escalated.repositories;
 
 import dev.escalated.models.SatisfactionRating;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,4 +18,23 @@ public interface SatisfactionRatingRepository extends JpaRepository<Satisfaction
 
     @Query("SELECT AVG(sr.rating) FROM SatisfactionRating sr")
     Double getAverageRating();
+
+    // ── Reporting aggregations ───────────────────────────────────────────────
+
+    @Query("SELECT AVG(sr.rating) FROM SatisfactionRating sr WHERE sr.createdAt >= :since")
+    Double avgRatingSince(@Param("since") Instant since);
+
+    @Query("SELECT COUNT(sr) FROM SatisfactionRating sr WHERE sr.createdAt >= :since")
+    long countRatingsSince(@Param("since") Instant since);
+
+    @Query("SELECT sr.rating, COUNT(sr) FROM SatisfactionRating sr "
+            + "WHERE sr.createdAt >= :since GROUP BY sr.rating ORDER BY sr.rating")
+    List<Object[]> countByRatingSince(@Param("since") Instant since);
+
+    @Query("SELECT sr.createdAt, sr.rating FROM SatisfactionRating sr WHERE sr.createdAt >= :since")
+    List<Object[]> ratingRowsSince(@Param("since") Instant since);
+
+    @Query("SELECT t.assignedAgent.id, AVG(sr.rating) FROM SatisfactionRating sr JOIN sr.ticket t "
+            + "WHERE t.assignedAgent IS NOT NULL AND sr.createdAt >= :since GROUP BY t.assignedAgent.id")
+    List<Object[]> avgRatingByAgentSince(@Param("since") Instant since);
 }

--- a/src/main/java/dev/escalated/repositories/TicketRepository.java
+++ b/src/main/java/dev/escalated/repositories/TicketRepository.java
@@ -16,6 +16,21 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
+    /**
+     * Shared JPQL predicate: a ticket has breached its SLA when a first
+     * response landed late, is overdue with no response yet, resolution
+     * landed late, or the ticket is still open past its resolution due time.
+     * Bound parameter {@code :now} must be supplied by any query using it.
+     */
+    String SLA_BREACH_PREDICATE =
+            "((t.firstRespondedAt IS NOT NULL AND t.slaFirstResponseDueAt IS NOT NULL "
+            + "AND t.firstRespondedAt > t.slaFirstResponseDueAt) "
+            + "OR (t.firstRespondedAt IS NULL AND t.slaFirstResponseDueAt IS NOT NULL "
+            + "AND t.slaFirstResponseDueAt < :now) "
+            + "OR (t.resolvedAt IS NOT NULL AND t.slaDueAt IS NOT NULL AND t.resolvedAt > t.slaDueAt) "
+            + "OR (t.resolvedAt IS NULL AND t.slaDueAt IS NOT NULL AND t.slaDueAt < :now "
+            + "AND t.status NOT IN ('CLOSED', 'RESOLVED', 'MERGED')))";
+
     Optional<Ticket> findByTicketNumber(String ticketNumber);
 
     Optional<Ticket> findByGuestAccessToken(String token);
@@ -57,4 +72,73 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
     long countByStatus(@Param("status") TicketStatus status);
 
     long countByRequesterEmail(String requesterEmail);
+
+    // ── Reporting aggregations ───────────────────────────────────────────────
+
+    @Query("SELECT COUNT(t) FROM Ticket t WHERE t.createdAt >= :since")
+    long countCreatedSince(@Param("since") Instant since);
+
+    @Query("SELECT COUNT(t) FROM Ticket t WHERE t.createdAt >= :start AND t.createdAt < :end")
+    long countCreatedBetween(@Param("start") Instant start, @Param("end") Instant end);
+
+    @Query("SELECT COUNT(t) FROM Ticket t WHERE t.resolvedAt IS NOT NULL AND t.resolvedAt >= :since")
+    long countResolvedSince(@Param("since") Instant since);
+
+    @Query("SELECT COUNT(t) FROM Ticket t WHERE t.resolvedAt IS NOT NULL "
+            + "AND t.resolvedAt >= :start AND t.resolvedAt < :end")
+    long countResolvedBetween(@Param("start") Instant start, @Param("end") Instant end);
+
+    @Query("SELECT t.status, COUNT(t) FROM Ticket t WHERE t.createdAt >= :since GROUP BY t.status")
+    List<Object[]> countByStatusSince(@Param("since") Instant since);
+
+    @Query("SELECT t.priority, COUNT(t) FROM Ticket t WHERE t.createdAt >= :since GROUP BY t.priority")
+    List<Object[]> countByPrioritySince(@Param("since") Instant since);
+
+    @Query("SELECT t.channel, COUNT(t) FROM Ticket t WHERE t.createdAt >= :since GROUP BY t.channel")
+    List<Object[]> countByChannelSince(@Param("since") Instant since);
+
+    @Query("SELECT t.createdAt FROM Ticket t WHERE t.createdAt >= :since")
+    List<Instant> createdAtSince(@Param("since") Instant since);
+
+    @Query("SELECT t.createdAt, t.firstRespondedAt FROM Ticket t "
+            + "WHERE t.createdAt >= :since AND t.firstRespondedAt IS NOT NULL")
+    List<Object[]> firstResponseTimings(@Param("since") Instant since);
+
+    @Query("SELECT t.createdAt, t.resolvedAt FROM Ticket t "
+            + "WHERE t.createdAt >= :since AND t.resolvedAt IS NOT NULL")
+    List<Object[]> resolutionTimings(@Param("since") Instant since);
+
+    @Query("SELECT COUNT(t) FROM Ticket t WHERE t.createdAt >= :since AND t.slaPolicy IS NOT NULL")
+    long countWithSlaSince(@Param("since") Instant since);
+
+    @Query("SELECT COUNT(t) FROM Ticket t WHERE t.createdAt >= :since AND t.slaFirstResponseDueAt IS NOT NULL "
+            + "AND ((t.firstRespondedAt IS NOT NULL AND t.firstRespondedAt > t.slaFirstResponseDueAt) "
+            + "OR (t.firstRespondedAt IS NULL AND t.slaFirstResponseDueAt < :now))")
+    long countFirstResponseBreaches(@Param("since") Instant since, @Param("now") Instant now);
+
+    @Query("SELECT COUNT(t) FROM Ticket t WHERE t.createdAt >= :since AND t.slaDueAt IS NOT NULL "
+            + "AND ((t.resolvedAt IS NOT NULL AND t.resolvedAt > t.slaDueAt) "
+            + "OR (t.resolvedAt IS NULL AND t.slaDueAt < :now "
+            + "AND t.status NOT IN ('CLOSED', 'RESOLVED', 'MERGED')))")
+    long countResolutionBreaches(@Param("since") Instant since, @Param("now") Instant now);
+
+    @Query("SELECT COUNT(t) FROM Ticket t WHERE t.createdAt >= :since AND t.slaPolicy IS NOT NULL "
+            + "AND " + SLA_BREACH_PREDICATE)
+    long countSlaBreaches(@Param("since") Instant since, @Param("now") Instant now);
+
+    @Query("SELECT t.priority, COUNT(t) FROM Ticket t "
+            + "WHERE t.createdAt >= :since AND t.slaPolicy IS NOT NULL GROUP BY t.priority")
+    List<Object[]> countSlaTicketsByPriority(@Param("since") Instant since);
+
+    @Query("SELECT t.priority, COUNT(t) FROM Ticket t WHERE t.createdAt >= :since AND t.slaPolicy IS NOT NULL "
+            + "AND " + SLA_BREACH_PREDICATE + " GROUP BY t.priority")
+    List<Object[]> countSlaBreachesByPriority(@Param("since") Instant since, @Param("now") Instant now);
+
+    @Query("SELECT a.id, a.name, COUNT(t), SUM(CASE WHEN t.resolvedAt IS NOT NULL THEN 1 ELSE 0 END) "
+            + "FROM Ticket t JOIN t.assignedAgent a WHERE t.createdAt >= :since GROUP BY a.id, a.name")
+    List<Object[]> agentTicketCounts(@Param("since") Instant since);
+
+    @Query("SELECT a.id, t.createdAt, t.firstRespondedAt FROM Ticket t JOIN t.assignedAgent a "
+            + "WHERE t.createdAt >= :since AND t.firstRespondedAt IS NOT NULL")
+    List<Object[]> agentFirstResponseTimings(@Param("since") Instant since);
 }

--- a/src/main/java/dev/escalated/services/AdvancedReportingService.java
+++ b/src/main/java/dev/escalated/services/AdvancedReportingService.java
@@ -1,15 +1,406 @@
 package dev.escalated.services;
 
+import dev.escalated.dto.reporting.AgentPerformanceReport;
+import dev.escalated.dto.reporting.CsatReport;
+import dev.escalated.dto.reporting.OverviewReport;
+import dev.escalated.dto.reporting.PeriodComparisonReport;
+import dev.escalated.dto.reporting.ReportSeriesPoint;
+import dev.escalated.dto.reporting.ResponseTimeReport;
+import dev.escalated.dto.reporting.SlaReport;
+import dev.escalated.dto.reporting.VolumeReport;
+import dev.escalated.repositories.SatisfactionRatingRepository;
+import dev.escalated.repositories.TicketRepository;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.springframework.stereotype.Service;
 
+/**
+ * Advanced reporting: repository aggregation queries fed through pure math
+ * helpers (percentiles, composite scores, date series, period changes) to
+ * produce the JSON report DTOs exposed by {@code AdminReportController}.
+ *
+ * <p>The {@code static} helpers below are pure functions covered by unit
+ * tests; the instance methods orchestrate the repositories and reuse them.
+ */
+@Service
 public class AdvancedReportingService {
 
+    private static final ZoneOffset ZONE = ZoneOffset.UTC;
+
+    private final TicketRepository ticketRepository;
+    private final SatisfactionRatingRepository satisfactionRatingRepository;
+
+    public AdvancedReportingService(TicketRepository ticketRepository,
+                                    SatisfactionRatingRepository satisfactionRatingRepository) {
+        this.ticketRepository = ticketRepository;
+        this.satisfactionRatingRepository = satisfactionRatingRepository;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Reports
+    // ──────────────────────────────────────────────────────────────────────
+
+    /** Headline dashboard metrics for the trailing {@code days}-day period. */
+    public OverviewReport overview(int days) {
+        Instant since = since(days);
+        Instant now = Instant.now();
+
+        long total = ticketRepository.countCreatedSince(since);
+        long resolved = ticketRepository.countResolvedSince(since);
+        double resolutionRate = total > 0 ? round1((double) resolved / total * 100) : 0.0;
+
+        double avgFrt = averageHours(ticketRepository.firstResponseTimings(since));
+        double avgResolution = averageHours(ticketRepository.resolutionTimings(since));
+
+        Double csat = satisfactionRatingRepository.avgRatingSince(since);
+        double csatAverage = csat == null ? 0.0 : round1(csat);
+
+        return new OverviewReport(
+                days,
+                total,
+                resolved,
+                resolutionRate,
+                round1(avgFrt),
+                round1(avgResolution),
+                slaComplianceRate(since, now),
+                csatAverage,
+                toSeries(ticketRepository.countByStatusSince(since)),
+                toSeries(ticketRepository.countByPrioritySince(since)),
+                toSeries(ticketRepository.countByChannelSince(since)));
+    }
+
+    /** First-response time distribution, percentiles, and daily trend. */
+    public ResponseTimeReport firstResponseTime(int days) {
+        return responseTime(days, ticketRepository.firstResponseTimings(since(days)), frtBuckets());
+    }
+
+    /** Resolution time distribution, percentiles, and daily trend. */
+    public ResponseTimeReport resolutionTime(int days) {
+        return responseTime(days, ticketRepository.resolutionTimings(since(days)), resolutionBuckets());
+    }
+
+    /** SLA compliance and breach trends, with a per-priority breakdown. */
+    public SlaReport slaReport(int days) {
+        Instant since = since(days);
+        Instant now = Instant.now();
+
+        long total = ticketRepository.countWithSlaSince(since);
+        long frtBreaches = ticketRepository.countFirstResponseBreaches(since, now);
+        long resolutionBreaches = ticketRepository.countResolutionBreaches(since, now);
+        long anyBreach = ticketRepository.countSlaBreaches(since, now);
+        double compliance = total > 0 ? round1((double) (total - anyBreach) / total * 100) : 100.0;
+
+        Map<String, Long> breachByPriority = new HashMap<>();
+        for (Object[] row : ticketRepository.countSlaBreachesByPriority(since, now)) {
+            breachByPriority.put(label(row[0]), asLong(row[1]));
+        }
+
+        List<SlaReport.PriorityBreakdown> byPriority = new ArrayList<>();
+        for (Object[] row : ticketRepository.countSlaTicketsByPriority(since)) {
+            String priority = label(row[0]);
+            long priorityTotal = asLong(row[1]);
+            long breached = breachByPriority.getOrDefault(priority, 0L);
+            double rate = priorityTotal > 0 ? round1((double) breached / priorityTotal * 100) : 0.0;
+            byPriority.add(new SlaReport.PriorityBreakdown(priority, priorityTotal, breached, rate));
+        }
+
+        return new SlaReport(days, compliance, total, frtBreaches, resolutionBreaches, anyBreach, byPriority);
+    }
+
+    /** CSAT average, response rate, rating breakdown, and daily trend. */
+    public CsatReport csat(int days) {
+        Instant since = since(days);
+
+        Double avg = satisfactionRatingRepository.avgRatingSince(since);
+        double average = avg == null ? 0.0 : round1(avg);
+        long totalRatings = satisfactionRatingRepository.countRatingsSince(since);
+        long totalTickets = ticketRepository.countCreatedSince(since);
+        double responseRate = totalTickets > 0 ? round1((double) totalRatings / totalTickets * 100) : 0.0;
+
+        List<ReportSeriesPoint> breakdown = toSeries(satisfactionRatingRepository.countByRatingSince(since));
+        List<CsatReport.TrendPoint> overTime = csatOverTime(satisfactionRatingRepository.ratingRowsSince(since));
+
+        return new CsatReport(days, average, totalRatings, responseRate, breakdown, overTime);
+    }
+
+    /** Daily ticket volume (zero-filled) plus priority and channel cohorts. */
+    public VolumeReport volume(int days) {
+        Instant since = since(days);
+        long total = ticketRepository.countCreatedSince(since);
+
+        Map<LocalDate, Long> counts = new HashMap<>();
+        for (Instant createdAt : ticketRepository.createdAtSince(since)) {
+            counts.merge(createdAt.atZone(ZONE).toLocalDate(), 1L, Long::sum);
+        }
+
+        LocalDate to = LocalDate.now(ZONE);
+        LocalDate from = to.minusDays(days);
+        List<ReportSeriesPoint> series = new ArrayList<>();
+        for (LocalDate date : dateSeries(from, to)) {
+            series.add(new ReportSeriesPoint(date.toString(), counts.getOrDefault(date, 0L)));
+        }
+
+        return new VolumeReport(
+                days,
+                total,
+                series,
+                toSeries(ticketRepository.countByPrioritySince(since)),
+                toSeries(ticketRepository.countByChannelSince(since)));
+    }
+
+    /** Ranked agent performance using {@link #compositeScore}. */
+    public AgentPerformanceReport agentPerformance(int days) {
+        Instant since = since(days);
+
+        Map<Long, List<Double>> frtByAgent = new HashMap<>();
+        for (Object[] row : ticketRepository.agentFirstResponseTimings(since)) {
+            long agentId = asLong(row[0]);
+            frtByAgent.computeIfAbsent(agentId, key -> new ArrayList<>())
+                    .add(hoursBetween((Instant) row[1], (Instant) row[2]));
+        }
+
+        Map<Long, Double> csatByAgent = new HashMap<>();
+        for (Object[] row : satisfactionRatingRepository.avgRatingByAgentSince(since)) {
+            csatByAgent.put(asLong(row[0]), asDouble(row[1]));
+        }
+
+        List<AgentPerformanceReport.AgentRow> rows = new ArrayList<>();
+        for (Object[] row : ticketRepository.agentTicketCounts(since)) {
+            long agentId = asLong(row[0]);
+            String name = (String) row[1];
+            long total = asLong(row[2]);
+            long resolved = asLong(row[3]);
+            double resolutionRate = total > 0 ? (double) resolved / total * 100 : 0.0;
+
+            List<Double> frtValues = frtByAgent.getOrDefault(agentId, Collections.emptyList());
+            Double avgFrt = frtValues.isEmpty()
+                    ? null
+                    : frtValues.stream().mapToDouble(Double::doubleValue).average().orElse(0);
+            Double avgCsat = csatByAgent.get(agentId);
+
+            double composite = compositeScore(resolutionRate, avgFrt, null, avgCsat);
+            rows.add(new AgentPerformanceReport.AgentRow(
+                    agentId,
+                    name,
+                    total,
+                    resolved,
+                    round1(resolutionRate),
+                    avgFrt == null ? 0.0 : round1(avgFrt),
+                    avgCsat == null ? 0.0 : round1(avgCsat),
+                    composite,
+                    0));
+        }
+
+        rows.sort((a, b) -> Double.compare(b.compositeScore(), a.compositeScore()));
+
+        List<AgentPerformanceReport.AgentRow> ranked = new ArrayList<>();
+        int rank = 1;
+        for (AgentPerformanceReport.AgentRow row : rows) {
+            ranked.add(new AgentPerformanceReport.AgentRow(
+                    row.agentId(),
+                    row.agentName(),
+                    row.totalTickets(),
+                    row.resolvedTickets(),
+                    row.resolutionRate(),
+                    row.avgResponseHours(),
+                    row.csatAverage(),
+                    row.compositeScore(),
+                    rank++));
+        }
+
+        return new AgentPerformanceReport(days, ranked);
+    }
+
+    /** Current period vs. the preceding equal-length period, with % changes. */
+    public PeriodComparisonReport periodComparison(int days) {
+        Instant now = Instant.now();
+        Instant currentStart = now.minus(days, ChronoUnit.DAYS);
+        Instant previousStart = now.minus(2L * days, ChronoUnit.DAYS);
+
+        Map<String, Double> current = periodMetrics(currentStart, now);
+        Map<String, Double> previous = periodMetrics(previousStart, currentStart);
+        Map<String, Double> changes = calculateChanges(current, previous);
+
+        return new PeriodComparisonReport(days, current, previous, changes);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Private orchestration helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private ResponseTimeReport responseTime(int days, List<Object[]> rows, Map<String, double[]> buckets) {
+        List<Double> hours = new ArrayList<>();
+        for (Object[] row : rows) {
+            hours.add(hoursBetween((Instant) row[0], (Instant) row[1]));
+        }
+
+        double avg = hours.isEmpty()
+                ? 0.0
+                : round1(hours.stream().mapToDouble(Double::doubleValue).average().orElse(0));
+
+        return new ResponseTimeReport(
+                days,
+                hours.size(),
+                avg,
+                buildHistogram(hours, buckets),
+                calculatePercentiles(hours),
+                responseTimeTrend(rows));
+    }
+
+    private List<ResponseTimeReport.TrendPoint> responseTimeTrend(List<Object[]> rows) {
+        Map<LocalDate, List<Double>> byDate = new TreeMap<>();
+        for (Object[] row : rows) {
+            Instant createdAt = (Instant) row[0];
+            byDate.computeIfAbsent(createdAt.atZone(ZONE).toLocalDate(), key -> new ArrayList<>())
+                    .add(hoursBetween(createdAt, (Instant) row[1]));
+        }
+
+        List<ResponseTimeReport.TrendPoint> trend = new ArrayList<>();
+        for (Map.Entry<LocalDate, List<Double>> entry : byDate.entrySet()) {
+            List<Double> values = entry.getValue();
+            double avg = round1(values.stream().mapToDouble(Double::doubleValue).average().orElse(0));
+            trend.add(new ResponseTimeReport.TrendPoint(entry.getKey().toString(), avg, values.size()));
+        }
+        return trend;
+    }
+
+    private List<CsatReport.TrendPoint> csatOverTime(List<Object[]> rows) {
+        Map<LocalDate, List<Integer>> byDate = new TreeMap<>();
+        for (Object[] row : rows) {
+            Instant createdAt = (Instant) row[0];
+            byDate.computeIfAbsent(createdAt.atZone(ZONE).toLocalDate(), key -> new ArrayList<>())
+                    .add((int) asLong(row[1]));
+        }
+
+        List<CsatReport.TrendPoint> trend = new ArrayList<>();
+        for (Map.Entry<LocalDate, List<Integer>> entry : byDate.entrySet()) {
+            List<Integer> values = entry.getValue();
+            double avg = round1(values.stream().mapToInt(Integer::intValue).average().orElse(0));
+            trend.add(new CsatReport.TrendPoint(entry.getKey().toString(), avg, values.size()));
+        }
+        return trend;
+    }
+
+    private double slaComplianceRate(Instant since, Instant now) {
+        long total = ticketRepository.countWithSlaSince(since);
+        if (total == 0) {
+            return 100.0;
+        }
+        long breached = ticketRepository.countSlaBreaches(since, now);
+        return round1((double) (total - breached) / total * 100);
+    }
+
+    private Map<String, Double> periodMetrics(Instant start, Instant end) {
+        long created = ticketRepository.countCreatedBetween(start, end);
+        long resolved = ticketRepository.countResolvedBetween(start, end);
+        double rate = created > 0 ? round1((double) resolved / created * 100) : 0.0;
+
+        Map<String, Double> metrics = new LinkedHashMap<>();
+        metrics.put("total_created", (double) created);
+        metrics.put("total_resolved", (double) resolved);
+        metrics.put("resolution_rate", rate);
+        return metrics;
+    }
+
+    private List<ReportSeriesPoint> toSeries(List<Object[]> rows) {
+        List<ReportSeriesPoint> series = new ArrayList<>();
+        for (Object[] row : rows) {
+            series.add(new ReportSeriesPoint(label(row[0]), asLong(row[1])));
+        }
+        return series;
+    }
+
+    private double averageHours(List<Object[]> rows) {
+        if (rows.isEmpty()) {
+            return 0.0;
+        }
+        double sum = 0;
+        for (Object[] row : rows) {
+            sum += hoursBetween((Instant) row[0], (Instant) row[1]);
+        }
+        return sum / rows.size();
+    }
+
+    private Instant since(int days) {
+        return Instant.now().minus(days, ChronoUnit.DAYS);
+    }
+
+    private static List<ResponseTimeReport.HistogramBucket> buildHistogram(List<Double> values,
+                                                                           Map<String, double[]> buckets) {
+        int total = values.size();
+        List<ResponseTimeReport.HistogramBucket> result = new ArrayList<>();
+        for (Map.Entry<String, double[]> entry : buckets.entrySet()) {
+            double min = entry.getValue()[0];
+            double max = entry.getValue()[1];
+            long count = values.stream()
+                    .filter(v -> v >= min && (v < max || max == Double.POSITIVE_INFINITY))
+                    .count();
+            double percentage = total > 0 ? round1((double) count / total * 100) : 0.0;
+            result.add(new ResponseTimeReport.HistogramBucket(entry.getKey(), count, percentage));
+        }
+        return result;
+    }
+
+    private static Map<String, double[]> frtBuckets() {
+        Map<String, double[]> buckets = new LinkedHashMap<>();
+        buckets.put("<1h", new double[] {0, 1});
+        buckets.put("1-4h", new double[] {1, 4});
+        buckets.put("4-8h", new double[] {4, 8});
+        buckets.put("8-24h", new double[] {8, 24});
+        buckets.put(">24h", new double[] {24, Double.POSITIVE_INFINITY});
+        return buckets;
+    }
+
+    private static Map<String, double[]> resolutionBuckets() {
+        Map<String, double[]> buckets = new LinkedHashMap<>();
+        buckets.put("<4h", new double[] {0, 4});
+        buckets.put("4-8h", new double[] {4, 8});
+        buckets.put("8-24h", new double[] {8, 24});
+        buckets.put("1-3d", new double[] {24, 72});
+        buckets.put("3-7d", new double[] {72, 168});
+        buckets.put(">7d", new double[] {168, Double.POSITIVE_INFINITY});
+        return buckets;
+    }
+
+    private static double hoursBetween(Instant from, Instant to) {
+        return (to.toEpochMilli() - from.toEpochMilli()) / 3_600_000.0;
+    }
+
+    private static double round1(double value) {
+        return Math.round(value * 10.0) / 10.0;
+    }
+
+    private static String label(Object value) {
+        return value == null ? "unknown" : value.toString();
+    }
+
+    private static long asLong(Object value) {
+        return ((Number) value).longValue();
+    }
+
+    private static double asDouble(Object value) {
+        return ((Number) value).doubleValue();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Pure math helpers (unit-tested)
+    // ──────────────────────────────────────────────────────────────────────
+
     public static Map<String, Double> calculatePercentiles(List<Double> values) {
-        if (values == null || values.isEmpty()) return Collections.emptyMap();
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyMap();
+        }
         List<Double> sorted = values.stream().sorted().collect(Collectors.toList());
         Map<String, Double> result = new LinkedHashMap<>();
         result.put("p50", percentileValue(sorted, 50));
@@ -21,20 +412,35 @@ public class AdvancedReportingService {
     }
 
     public static double percentileValue(List<Double> sorted, double p) {
-        if (sorted.size() == 1) return Math.round(sorted.get(0) * 100.0) / 100.0;
+        if (sorted.size() == 1) {
+            return Math.round(sorted.get(0) * 100.0) / 100.0;
+        }
         double k = (p / 100) * (sorted.size() - 1);
         int f = (int) Math.floor(k);
         int c = (int) Math.ceil(k);
-        if (f == c) return Math.round(sorted.get(f) * 100.0) / 100.0;
+        if (f == c) {
+            return Math.round(sorted.get(f) * 100.0) / 100.0;
+        }
         return Math.round((sorted.get(f) + (k - f) * (sorted.get(c) - sorted.get(f))) * 100.0) / 100.0;
     }
 
     public static double compositeScore(double resolutionRate, Double avgFrt, Double avgResolution, Double avgCsat) {
-        double score = 0, weights = 0;
-        score += (resolutionRate / 100) * 30; weights += 30;
-        if (avgFrt != null && avgFrt > 0) { score += Math.max(1 - avgFrt / 24, 0) * 25; weights += 25; }
-        if (avgResolution != null && avgResolution > 0) { score += Math.max(1 - avgResolution / 72, 0) * 25; weights += 25; }
-        if (avgCsat != null) { score += (avgCsat / 5) * 20; weights += 20; }
+        double score = 0;
+        double weights = 0;
+        score += (resolutionRate / 100) * 30;
+        weights += 30;
+        if (avgFrt != null && avgFrt > 0) {
+            score += Math.max(1 - avgFrt / 24, 0) * 25;
+            weights += 25;
+        }
+        if (avgResolution != null && avgResolution > 0) {
+            score += Math.max(1 - avgResolution / 72, 0) * 25;
+            weights += 25;
+        }
+        if (avgCsat != null) {
+            score += (avgCsat / 5) * 20;
+            weights += 20;
+        }
         return weights > 0 ? Math.round((score / weights) * 1000.0) / 10.0 : 0;
     }
 

--- a/src/test/java/dev/escalated/controllers/AdminReportControllerTest.java
+++ b/src/test/java/dev/escalated/controllers/AdminReportControllerTest.java
@@ -1,0 +1,203 @@
+package dev.escalated.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import dev.escalated.controllers.admin.AdminReportController;
+import dev.escalated.models.AgentProfile;
+import dev.escalated.models.SatisfactionRating;
+import dev.escalated.models.SlaPolicy;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketPriority;
+import dev.escalated.models.TicketStatus;
+import dev.escalated.repositories.AgentProfileRepository;
+import dev.escalated.repositories.SatisfactionRatingRepository;
+import dev.escalated.repositories.SlaPolicyRepository;
+import dev.escalated.repositories.TicketRepository;
+import dev.escalated.services.AdvancedReportingService;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * End-to-end reachability test for the reporting endpoints: seeds tickets and
+ * ratings, then drives the real controller (backed by the real service and
+ * repositories over a seeded H2 database) through MockMvc, asserting each
+ * report comes back populated as JSON.
+ */
+@DataJpaTest
+@Import({AdvancedReportingService.class, AdminReportController.class})
+@TestPropertySource(
+        properties = {
+            "spring.jpa.hibernate.ddl-auto=create-drop",
+            "spring.flyway.enabled=false",
+        })
+class AdminReportControllerTest {
+
+    @Autowired private TicketRepository tickets;
+    @Autowired private SatisfactionRatingRepository ratings;
+    @Autowired private AgentProfileRepository agents;
+    @Autowired private SlaPolicyRepository slaPolicies;
+    @Autowired private AdminReportController controller;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+        AgentProfile alice = agent("Alice", "alice@example.com");
+        AgentProfile bob = agent("Bob", "bob@example.com");
+        SlaPolicy sla = slaPolicy();
+
+        Ticket t1 = ticket("ESC-1", TicketPriority.HIGH, "email", TicketStatus.RESOLVED, alice, sla,
+                2.0, 10.0, 4.0, 24.0);
+        Ticket t2 = ticket("ESC-2", TicketPriority.MEDIUM, "web", TicketStatus.RESOLVED, alice, sla,
+                6.0, 30.0, 4.0, 24.0);
+        ticket("ESC-3", TicketPriority.LOW, "chat", TicketStatus.OPEN, bob, null,
+                1.0, null, null, null);
+
+        rating(t1, 5);
+        rating(t2, 3);
+    }
+
+    @Test
+    void overview_endpointReturnsPopulatedReport() throws Exception {
+        mockMvc.perform(get("/escalated/api/admin/reports/overview").param("days", "30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.period_days").value(30))
+                .andExpect(jsonPath("$.total_tickets").value(3))
+                .andExpect(jsonPath("$.resolved_tickets").value(2))
+                .andExpect(jsonPath("$.by_priority").isNotEmpty())
+                .andExpect(jsonPath("$.by_channel").isNotEmpty());
+    }
+
+    @Test
+    void slaEndpoint_returnsBreachCounts() throws Exception {
+        mockMvc.perform(get("/escalated/api/admin/reports/sla").param("days", "30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_with_sla").value(2))
+                .andExpect(jsonPath("$.first_response_breaches").value(1))
+                .andExpect(jsonPath("$.by_priority").isArray());
+    }
+
+    @Test
+    void firstResponseTimeEndpoint_returnsDistribution() throws Exception {
+        mockMvc.perform(get("/escalated/api/admin/reports/first-response-time").param("days", "30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_measured").value(3))
+                .andExpect(jsonPath("$.distribution").isArray())
+                .andExpect(jsonPath("$.percentiles.p50").exists());
+    }
+
+    @Test
+    void resolutionTimeEndpoint_returnsDistribution() throws Exception {
+        mockMvc.perform(get("/escalated/api/admin/reports/resolution-time").param("days", "30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_measured").value(2));
+    }
+
+    @Test
+    void csatEndpoint_returnsRatings() throws Exception {
+        mockMvc.perform(get("/escalated/api/admin/reports/csat").param("days", "30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_ratings").value(2))
+                .andExpect(jsonPath("$.average").value(4.0));
+    }
+
+    @Test
+    void volumeEndpoint_returnsSeries() throws Exception {
+        mockMvc.perform(get("/escalated/api/admin/reports/volume").param("days", "30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_tickets").value(3))
+                .andExpect(jsonPath("$.series").isNotEmpty());
+    }
+
+    @Test
+    void agentPerformanceEndpoint_returnsRankedAgents() throws Exception {
+        mockMvc.perform(get("/escalated/api/admin/reports/agent-performance").param("days", "30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.agents").isArray())
+                .andExpect(jsonPath("$.agents[0].rank").value(1));
+    }
+
+    @Test
+    void periodComparisonEndpoint_returnsChanges() throws Exception {
+        mockMvc.perform(get("/escalated/api/admin/reports/period-comparison").param("days", "30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.current.total_created").value(3.0))
+                .andExpect(jsonPath("$.changes").exists());
+    }
+
+    @Test
+    void defaultsToThirtyDaysWhenParamOmitted() throws Exception {
+        mockMvc.perform(get("/escalated/api/admin/reports/overview"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.period_days").value(30));
+    }
+
+    // ── seeding helpers ──────────────────────────────────────────────────────
+
+    private AgentProfile agent(String name, String email) {
+        AgentProfile agent = new AgentProfile();
+        agent.setName(name);
+        agent.setEmail(email);
+        return agents.saveAndFlush(agent);
+    }
+
+    private SlaPolicy slaPolicy() {
+        SlaPolicy policy = new SlaPolicy();
+        policy.setName("Standard");
+        policy.setFirstResponseMinutes(240);
+        policy.setResolutionMinutes(1440);
+        return slaPolicies.saveAndFlush(policy);
+    }
+
+    private Ticket ticket(String number, TicketPriority priority, String channel, TicketStatus status,
+                          AgentProfile agent, SlaPolicy sla,
+                          Double frtHours, Double resolutionHours,
+                          Double frtDueHours, Double resolutionDueHours) {
+        Ticket ticket = new Ticket();
+        ticket.setSubject("Subject " + number);
+        ticket.setBody("Body");
+        ticket.setTicketNumber(number);
+        ticket.setRequesterName("Requester");
+        ticket.setRequesterEmail("requester@example.com");
+        ticket.setPriority(priority);
+        ticket.setChannel(channel);
+        ticket.setStatus(status);
+        ticket.setAssignedAgent(agent);
+        ticket.setSlaPolicy(sla);
+        ticket = tickets.saveAndFlush(ticket);
+
+        Instant created = ticket.getCreatedAt();
+        if (frtHours != null) {
+            ticket.setFirstRespondedAt(created.plusSeconds((long) (frtHours * 3600)));
+        }
+        if (resolutionHours != null) {
+            ticket.setResolvedAt(created.plusSeconds((long) (resolutionHours * 3600)));
+        }
+        if (frtDueHours != null) {
+            ticket.setSlaFirstResponseDueAt(created.plusSeconds((long) (frtDueHours * 3600)));
+        }
+        if (resolutionDueHours != null) {
+            ticket.setSlaDueAt(created.plusSeconds((long) (resolutionDueHours * 3600)));
+        }
+        return tickets.saveAndFlush(ticket);
+    }
+
+    private void rating(Ticket ticket, int value) {
+        SatisfactionRating rating = new SatisfactionRating();
+        rating.setTicket(ticket);
+        rating.setRating(value);
+        rating.setRaterEmail("rater@example.com");
+        ratings.saveAndFlush(rating);
+    }
+}

--- a/src/test/java/dev/escalated/services/AdvancedReportingServiceDbTest.java
+++ b/src/test/java/dev/escalated/services/AdvancedReportingServiceDbTest.java
@@ -1,0 +1,248 @@
+package dev.escalated.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.escalated.dto.reporting.AgentPerformanceReport;
+import dev.escalated.dto.reporting.CsatReport;
+import dev.escalated.dto.reporting.OverviewReport;
+import dev.escalated.dto.reporting.PeriodComparisonReport;
+import dev.escalated.dto.reporting.ResponseTimeReport;
+import dev.escalated.dto.reporting.SlaReport;
+import dev.escalated.dto.reporting.VolumeReport;
+import dev.escalated.models.AgentProfile;
+import dev.escalated.models.SatisfactionRating;
+import dev.escalated.models.SlaPolicy;
+import dev.escalated.models.Ticket;
+import dev.escalated.models.TicketPriority;
+import dev.escalated.models.TicketStatus;
+import dev.escalated.repositories.AgentProfileRepository;
+import dev.escalated.repositories.SatisfactionRatingRepository;
+import dev.escalated.repositories.SlaPolicyRepository;
+import dev.escalated.repositories.TicketRepository;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Proves the reporting aggregation queries + math produce correct, populated
+ * reports over a deterministic set of seeded tickets and ratings.
+ */
+@DataJpaTest
+@Import(AdvancedReportingService.class)
+@TestPropertySource(
+        properties = {
+            "spring.jpa.hibernate.ddl-auto=create-drop",
+            "spring.flyway.enabled=false",
+        })
+class AdvancedReportingServiceDbTest {
+
+    private static final double DELTA = 0.05;
+
+    @Autowired private TicketRepository tickets;
+    @Autowired private SatisfactionRatingRepository ratings;
+    @Autowired private AgentProfileRepository agents;
+    @Autowired private SlaPolicyRepository slaPolicies;
+    @Autowired private AdvancedReportingService reporting;
+
+    private AgentProfile alice;
+    private AgentProfile bob;
+
+    @BeforeEach
+    void seed() {
+        alice = agent("Alice", "alice@example.com");
+        bob = agent("Bob", "bob@example.com");
+        SlaPolicy sla = slaPolicy();
+
+        // Ticket 1: resolved, met both SLAs. FRT 2h, resolution 10h.
+        Ticket t1 = ticket("ESC-1", TicketPriority.HIGH, "email", TicketStatus.RESOLVED, alice, sla,
+                2.0, 10.0, 4.0, 24.0);
+        // Ticket 2: resolved, breached both SLAs. FRT 6h, resolution 30h.
+        Ticket t2 = ticket("ESC-2", TicketPriority.HIGH, "email", TicketStatus.RESOLVED, alice, sla,
+                6.0, 30.0, 4.0, 24.0);
+        // Ticket 3: open, met FRT, resolution due in the future -> not breached. FRT 1h.
+        Ticket t3 = ticket("ESC-3", TicketPriority.LOW, "web", TicketStatus.OPEN, bob, sla,
+                1.0, null, 8.0, 48.0);
+        // Ticket 4: open, no SLA policy, never responded.
+        ticket("ESC-4", TicketPriority.MEDIUM, "chat", TicketStatus.OPEN, null, null,
+                null, null, null, null);
+
+        rating(t1, 5);
+        rating(t2, 2);
+        rating(t3, 4);
+    }
+
+    @Test
+    void overview_summarisesSeededTickets() {
+        OverviewReport report = reporting.overview(30);
+
+        assertThat(report.periodDays()).isEqualTo(30);
+        assertThat(report.totalTickets()).isEqualTo(4);
+        assertThat(report.resolvedTickets()).isEqualTo(2);
+        assertThat(report.resolutionRate()).isEqualTo(50.0);
+        assertThat(report.avgFirstResponseHours()).isEqualTo(3.0, org.assertj.core.data.Offset.offset(DELTA));
+        assertThat(report.avgResolutionHours()).isEqualTo(20.0, org.assertj.core.data.Offset.offset(DELTA));
+        assertThat(report.slaComplianceRate()).isEqualTo(66.7, org.assertj.core.data.Offset.offset(DELTA));
+        assertThat(report.csatAverage()).isEqualTo(3.7, org.assertj.core.data.Offset.offset(DELTA));
+
+        assertThat(report.byStatus()).extracting("label").contains("RESOLVED", "OPEN");
+        assertThat(report.byPriority()).extracting("label").contains("HIGH", "LOW", "MEDIUM");
+        assertThat(report.byChannel()).extracting("label").contains("email", "web", "chat");
+        assertThat(seriesTotal(report.byPriority())).isEqualTo(4);
+    }
+
+    @Test
+    void slaReport_countsBreachesAndCompliance() {
+        SlaReport report = reporting.slaReport(30);
+
+        assertThat(report.totalWithSla()).isEqualTo(3);
+        assertThat(report.firstResponseBreaches()).isEqualTo(1);
+        assertThat(report.resolutionBreaches()).isEqualTo(1);
+        assertThat(report.totalBreaches()).isEqualTo(1);
+        assertThat(report.complianceRate()).isEqualTo(66.7, org.assertj.core.data.Offset.offset(DELTA));
+
+        SlaReport.PriorityBreakdown high = report.byPriority().stream()
+                .filter(p -> p.priority().equals("HIGH"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(high.total()).isEqualTo(2);
+        assertThat(high.breached()).isEqualTo(1);
+        assertThat(high.breachRate()).isEqualTo(50.0, org.assertj.core.data.Offset.offset(DELTA));
+    }
+
+    @Test
+    void firstResponseTime_distributionAndPercentiles() {
+        ResponseTimeReport report = reporting.firstResponseTime(30);
+
+        assertThat(report.totalMeasured()).isEqualTo(3);
+        assertThat(report.avgHours()).isEqualTo(3.0, org.assertj.core.data.Offset.offset(DELTA));
+        assertThat(report.percentiles().get("p50")).isEqualTo(2.0, org.assertj.core.data.Offset.offset(DELTA));
+
+        long bucketTotal = report.distribution().stream()
+                .mapToLong(ResponseTimeReport.HistogramBucket::count)
+                .sum();
+        assertThat(bucketTotal).isEqualTo(3);
+        assertThat(report.trend()).isNotEmpty();
+    }
+
+    @Test
+    void resolutionTime_measuresResolvedTickets() {
+        ResponseTimeReport report = reporting.resolutionTime(30);
+
+        assertThat(report.totalMeasured()).isEqualTo(2);
+        assertThat(report.avgHours()).isEqualTo(20.0, org.assertj.core.data.Offset.offset(DELTA));
+    }
+
+    @Test
+    void csat_averagesAndBreaksDownRatings() {
+        CsatReport report = reporting.csat(30);
+
+        assertThat(report.totalRatings()).isEqualTo(3);
+        assertThat(report.average()).isEqualTo(3.7, org.assertj.core.data.Offset.offset(DELTA));
+        assertThat(report.breakdown()).isNotEmpty();
+        assertThat(report.overTime()).isNotEmpty();
+    }
+
+    @Test
+    void volume_producesZeroFilledSeriesAndCohorts() {
+        VolumeReport report = reporting.volume(30);
+
+        assertThat(report.totalTickets()).isEqualTo(4);
+        assertThat(report.series()).isNotEmpty();
+        assertThat(seriesTotal(report.series())).isEqualTo(4);
+        assertThat(report.byPriority()).isNotEmpty();
+        assertThat(report.byChannel()).isNotEmpty();
+    }
+
+    @Test
+    void agentPerformance_ranksByCompositeScore() {
+        AgentPerformanceReport report = reporting.agentPerformance(30);
+
+        assertThat(report.agents()).hasSize(2);
+        AgentPerformanceReport.AgentRow first = report.agents().get(0);
+        AgentPerformanceReport.AgentRow second = report.agents().get(1);
+        assertThat(first.rank()).isEqualTo(1);
+        assertThat(second.rank()).isEqualTo(2);
+        assertThat(first.compositeScore()).isGreaterThanOrEqualTo(second.compositeScore());
+        assertThat(first.agentName()).isEqualTo("Alice");
+        assertThat(first.totalTickets()).isEqualTo(2);
+        assertThat(first.resolvedTickets()).isEqualTo(2);
+    }
+
+    @Test
+    void periodComparison_reportsCurrentAndChanges() {
+        PeriodComparisonReport report = reporting.periodComparison(30);
+
+        assertThat(report.current().get("total_created")).isEqualTo(4.0);
+        assertThat(report.changes()).containsKeys("total_created", "total_resolved", "resolution_rate");
+    }
+
+    // ── seeding helpers ──────────────────────────────────────────────────────
+
+    private long seriesTotal(java.util.List<dev.escalated.dto.reporting.ReportSeriesPoint> series) {
+        return series.stream().mapToLong(dev.escalated.dto.reporting.ReportSeriesPoint::value).sum();
+    }
+
+    private AgentProfile agent(String name, String email) {
+        AgentProfile agent = new AgentProfile();
+        agent.setName(name);
+        agent.setEmail(email);
+        return agents.saveAndFlush(agent);
+    }
+
+    private SlaPolicy slaPolicy() {
+        SlaPolicy policy = new SlaPolicy();
+        policy.setName("Standard");
+        policy.setFirstResponseMinutes(240);
+        policy.setResolutionMinutes(1440);
+        return slaPolicies.saveAndFlush(policy);
+    }
+
+    private Ticket ticket(String number, TicketPriority priority, String channel, TicketStatus status,
+                          AgentProfile agent, SlaPolicy sla,
+                          Double frtHours, Double resolutionHours,
+                          Double frtDueHours, Double resolutionDueHours) {
+        Ticket ticket = new Ticket();
+        ticket.setSubject("Subject " + number);
+        ticket.setBody("Body");
+        ticket.setTicketNumber(number);
+        ticket.setRequesterName("Requester");
+        ticket.setRequesterEmail("requester@example.com");
+        ticket.setPriority(priority);
+        ticket.setChannel(channel);
+        ticket.setStatus(status);
+        ticket.setAssignedAgent(agent);
+        ticket.setSlaPolicy(sla);
+        ticket = tickets.saveAndFlush(ticket);
+
+        Instant created = ticket.getCreatedAt();
+        if (frtHours != null) {
+            ticket.setFirstRespondedAt(plusHours(created, frtHours));
+        }
+        if (resolutionHours != null) {
+            ticket.setResolvedAt(plusHours(created, resolutionHours));
+        }
+        if (frtDueHours != null) {
+            ticket.setSlaFirstResponseDueAt(plusHours(created, frtDueHours));
+        }
+        if (resolutionDueHours != null) {
+            ticket.setSlaDueAt(plusHours(created, resolutionDueHours));
+        }
+        return tickets.saveAndFlush(ticket);
+    }
+
+    private void rating(Ticket ticket, int value) {
+        SatisfactionRating rating = new SatisfactionRating();
+        rating.setTicket(ticket);
+        rating.setRating(value);
+        rating.setRaterEmail("rater@example.com");
+        ratings.saveAndFlush(rating);
+    }
+
+    private static Instant plusHours(Instant base, double hours) {
+        return base.plusSeconds((long) (hours * 3600));
+    }
+}


### PR DESCRIPTION
## Summary

`AdvancedReportingService` previously contained only static percentile / composite-score / date-series math helpers — no data access and no HTTP surface, so no analytics could actually be retrieved. This PR makes advanced reporting **functional and reachable** by adding the missing layers around those helpers, mirroring the report surface of the Laravel host (`ReportingService` + `Admin\ReportController`).

## What was added

- **Repository aggregation queries** (portable JPQL, mirroring existing query style):
  - `TicketRepository`: created/resolved counts (`countCreatedSince`, `countResolvedSince`, `*Between`), grouped counts (`countByStatusSince`, `countByPrioritySince`, `countByChannelSince`), timing projections (`firstResponseTimings`, `resolutionTimings`, `createdAtSince`), SLA counts (`countWithSlaSince`, `countFirstResponseBreaches`, `countResolutionBreaches`, `countSlaBreaches`, `countSla*ByPriority`), and per-agent aggregates (`agentTicketCounts`, `agentFirstResponseTimings`). A shared `SLA_BREACH_PREDICATE` constant keeps the breach logic in one place.
  - `SatisfactionRatingRepository`: `avgRatingSince`, `countRatingsSince`, `countByRatingSince`, `ratingRowsSince`, `avgRatingByAgentSince`.
- **Service methods** on `AdvancedReportingService` (now a `@Service`) that pipe those datasets through the **existing** math helpers — `calculatePercentiles`, `compositeScore`, `dateSeries`, `calculateChanges` are all reused. The static helpers are untouched (their unit tests still pass).
- **JSON report DTOs** (`dev.escalated.dto.reporting`, snake_case via `@JsonProperty`).
- **`AdminReportController`** at `/escalated/api/admin/reports/*`, admin-secured by the existing `/escalated/api/**` token filter chain like every other admin controller.

## Endpoints

| Endpoint | Report |
|---|---|
| `GET /escalated/api/admin/reports/overview` | totals, avg FRT/resolution, SLA compliance, CSAT, status/priority/channel counts |
| `GET /escalated/api/admin/reports/sla` | compliance rate, FRT/resolution/total breaches, per-priority breach rates |
| `GET /escalated/api/admin/reports/first-response-time` | histogram, percentiles, daily trend |
| `GET /escalated/api/admin/reports/resolution-time` | histogram, percentiles, daily trend |
| `GET /escalated/api/admin/reports/csat` | average, response rate, rating breakdown, daily trend |
| `GET /escalated/api/admin/reports/volume` | zero-filled daily series, priority/channel cohorts |
| `GET /escalated/api/admin/reports/agent-performance` | ranked agents with composite score |
| `GET /escalated/api/admin/reports/period-comparison` | current vs. previous period, % changes |

All take an optional `days` param (default 30).

## Tests (TDD, run locally with `./gradlew check` — green)

- `AdvancedReportingServiceDbTest` (`@DataJpaTest`): seeds a deterministic set of tickets/ratings and asserts each report's exact numbers (counts, avg hours, p50, SLA breach counts, composite ranking).
- `AdminReportControllerTest`: drives the real controller → service → repositories over a seeded H2 database through MockMvc, asserting each endpoint returns a populated JSON report.

No regressions; full `check` (all tests + checkstyle) passes.